### PR TITLE
Port behavior_velocity_planner to ROS2 (review PR)

### DIFF
--- a/common/msgs/autoware_perception_msgs/CMakeLists.txt
+++ b/common/msgs/autoware_perception_msgs/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TRAFFIC_LIGHT_RECOGNITION_MSG_FILES
   "TrafficLightRoiArray.msg"
   "TrafficLightState.msg"
   "TrafficLightStateArray.msg"
+  "TrafficLightStateStamped.msg"
 )
 
 if(${ROS_VERSION} EQUAL 1)

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/CMakeLists.txt
@@ -9,49 +9,47 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-unused-parameter -Wall -Wextra -Wpedantic)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS
+find_package(ament_cmake REQUIRED)
+find_package(autoware_perception_msgs REQUIRED)
+find_package(autoware_planning_msgs REQUIRED)
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(lanelet2_extension REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common)
+find_package(pcl_conversions REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(spline_interpolation REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_eigen REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(vehicle_info_util REQUIRED)
+find_package(visualization_msgs REQUIRED)
+
+set(BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES
+  ament_cmake
   autoware_perception_msgs
   autoware_planning_msgs
-  autoware_perception_msgs
+  Eigen3
+  diagnostic_msgs
   geometry_msgs
   lanelet2_extension
-  pcl_ros
-  roscpp
+  PCL
+  pcl_conversions
+  rclcpp
   sensor_msgs
   spline_interpolation
   tf2
   tf2_eigen
   tf2_geometry_msgs
   tf2_ros
+  vehicle_info_util
   visualization_msgs
 )
 
-find_package(Eigen3 REQUIRED)
-
-catkin_package(
-  INCLUDE_DIRS
-    include
-  CATKIN_DEPENDS
-    autoware_perception_msgs
-    autoware_planning_msgs
-    autoware_perception_msgs
-    geometry_msgs
-    lanelet2_extension
-    pcl_ros
-    sensor_msgs
-    spline_interpolation
-    tf2
-    tf2_eigen
-    tf2_geometry_msgs
-    tf2_ros
-    visualization_msgs
-)
-
-include_directories(
-  include
-  ${EIGEN3_INCLUDE_DIRS}
-  ${catkin_INCLUDE_DIRS}
-)
 
 # Common
 add_library(scene_module_lib STATIC
@@ -60,14 +58,15 @@ add_library(scene_module_lib STATIC
   src/utilization/interpolate.cpp
 )
 
-add_dependencies(scene_module_lib
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_lib
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_lib ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(behavior_velocity_planner_node scene_module_lib)
 
 # Scene Module: Stop Line
 add_library(scene_module_stop_line STATIC
@@ -76,15 +75,16 @@ add_library(scene_module_stop_line STATIC
   src/scene_module/stop_line/debug.cpp
 )
 
-add_dependencies(scene_module_stop_line
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_stop_line
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_stop_line
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_stop_line ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_stop_line scene_module_lib)
+
 
 # Scene Module: Crosswalk
 add_library(scene_module_crosswalk STATIC
@@ -95,15 +95,16 @@ add_library(scene_module_crosswalk STATIC
   src/scene_module/crosswalk/util.cpp
 )
 
-add_dependencies(scene_module_crosswalk
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_crosswalk
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_crosswalk
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_crosswalk ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_crosswalk scene_module_lib)
+
 
 # Scene Module: Intersection
 add_library(scene_module_intersection STATIC
@@ -114,15 +115,16 @@ add_library(scene_module_intersection STATIC
   src/scene_module/intersection/util.cpp
 )
 
-add_dependencies(scene_module_intersection
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_intersection
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_intersection
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_intersection ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_intersection scene_module_lib)
+
 
 # Scene Module: Traffic Light
 add_library(scene_module_traffic_light STATIC
@@ -131,15 +133,16 @@ add_library(scene_module_traffic_light STATIC
   src/scene_module/traffic_light/debug.cpp
 )
 
-add_dependencies(scene_module_traffic_light
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_traffic_light
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_traffic_light
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_traffic_light ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_traffic_light scene_module_lib)
+
 
 # Scene Module: Blind Spot
 add_library(scene_module_blind_spot STATIC
@@ -148,15 +151,16 @@ add_library(scene_module_blind_spot STATIC
   src/scene_module/blind_spot/debug.cpp
 )
 
-add_dependencies(scene_module_blind_spot
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_blind_spot
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_blind_spot
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_blind_spot ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_blind_spot scene_module_lib)
+
 
 # Scene Module: Detection Area
 add_library(scene_module_detection_area STATIC
@@ -165,34 +169,32 @@ add_library(scene_module_detection_area STATIC
   src/scene_module/detection_area/debug.cpp
 )
 
-add_dependencies(scene_module_detection_area
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_detection_area
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_detection_area
-  scene_module_lib
-  ${catkin_LIBRARIES}
-)
+ament_target_dependencies(scene_module_detection_area ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_detection_area scene_module_lib)
+
 
 # Scene Module Manager
 add_library(scene_module_manager STATIC
   src/planner_manager.cpp
 )
 
-add_dependencies(scene_module_manager
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(scene_module_manager
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(scene_module_manager
-  scene_module_stop_line
-  scene_module_crosswalk
-  scene_module_intersection
-  scene_module_traffic_light
-  scene_module_blind_spot
-  scene_module_detection_area
-)
+ament_target_dependencies(scene_module_manager ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+
+target_link_libraries(scene_module_manager scene_module_lib)
+
 
 # Node
 add_executable(behavior_velocity_planner_node
@@ -200,27 +202,24 @@ add_executable(behavior_velocity_planner_node
   src/main.cpp
 )
 
-add_dependencies(behavior_velocity_planner_node
-  ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS}
+target_include_directories(behavior_velocity_planner_node
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
+
+ament_target_dependencies(behavior_velocity_planner_node ${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES} )
 
 target_link_libraries(behavior_velocity_planner_node
+  scene_module_lib
+  scene_module_stop_line
+  scene_module_crosswalk
+  scene_module_intersection
+  scene_module_traffic_light
+  scene_module_blind_spot
+  scene_module_detection_area
   scene_module_manager
-  ${catkin_LIBRARIES}
 )
 
-install(
-  TARGETS
-    behavior_velocity_planner_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-install(
-  DIRECTORY
-    config
-    launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+ament_export_dependencies(${BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES})
+ament_package()

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/node.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/node.h
@@ -28,7 +28,7 @@
 #include <behavior_velocity_planner/planner_data.h>
 #include <behavior_velocity_planner/planner_manager.h>
 
-class BehaviorVelocityPlannerNode: public rclcpp::Node
+class BehaviorVelocityPlannerNode : public rclcpp::Node
 {
 public:
   BehaviorVelocityPlannerNode();
@@ -39,26 +39,31 @@ private:
   tf2_ros::TransformListener tf_listener_;
 
   // subscriber
-  rclcpp::Subscription<autoware_planning_msgs::msg::PathWithLaneId>::SharedPtr trigger_sub_path_with_lane_id_;
-  rclcpp::Subscription<autoware_perception_msgs::msg::DynamicObjectArray>::SharedPtr sub_dynamic_objects_;
+  rclcpp::Subscription<autoware_planning_msgs::msg::PathWithLaneId>::SharedPtr
+    trigger_sub_path_with_lane_id_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::DynamicObjectArray>::SharedPtr
+    sub_dynamic_objects_;
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_no_ground_pointcloud_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr sub_vehicle_velocity_;
   rclcpp::Subscription<autoware_lanelet2_msgs::msg::MapBin>::SharedPtr sub_lanelet_map_;
-  rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightStateArray>::SharedPtr sub_traffic_light_states_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightStateArray>::SharedPtr
+    sub_traffic_light_states_;
 
   void onTrigger(const autoware_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg);
-  void onDynamicObjects(const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr msg);
+  void onDynamicObjects(
+    const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr msg);
   void onNoGroundPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
   void onVehicleVelocity(const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg);
   void onLaneletMap(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg);
-  void onTrafficLightStates(const autoware_perception_msgs::msg::TrafficLightStateArray::ConstSharedPtr msg);
+  void onTrafficLightStates(
+    const autoware_perception_msgs::msg::TrafficLightStateArray::ConstSharedPtr msg);
 
   // publisher
   rclcpp::Publisher<autoware_planning_msgs::msg::Path>::SharedPtr path_pub_;
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr stop_reason_diag_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
 
-  void publishDebugMarker(const autoware_planning_msgs::msg::Path & path, const rclcpp::Publisher & pub);
+  void publishDebugMarker(const autoware_planning_msgs::msg::Path & path);
 
   //  parameter
   double forward_path_length_;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_data.h
@@ -32,15 +32,21 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
+#include <vehicle_info_util/vehicle_info.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 
-
 struct PlannerData
 {
+  PlannerData(rclcpp::Node & node) : vehicle_info_(vehicle_info_util::VehicleInfo::create(node))
+  {
+    max_stop_acceleration_threshold_ = node.declare_parameter(
+      "max_accel", -5.0);  // TODO read min_acc in velocity_controller_param.yaml?
+    delay_response_time_ = node.declare_parameter("delay_response_time", 1.3);
+  }
   // tf
   geometry_msgs::msg::PoseStamped current_pose;
 
@@ -57,10 +63,7 @@ struct PlannerData
   std::shared_ptr<const lanelet::routing::RoutingGraphContainer> overall_graphs;
 
   // parameters
-  double wheel_base;
-  double front_overhang;
-  double vehicle_width;
-  double base_link2front;
+  vehicle_info_util::VehicleInfo vehicle_info_;
 
   // additional parameters
   double max_stop_acceleration_threshold_;
@@ -72,11 +75,13 @@ struct PlannerData
     return current_velocity->twist.linear.x < 0.1;
   }
 
-  std::shared_ptr<autoware_perception_msgs::msg::TrafficLightStateStamped> getTrafficLightState(const int id) const
+  std::shared_ptr<autoware_perception_msgs::msg::TrafficLightStateStamped> getTrafficLightState(
+    const int id) const
   {
     if (traffic_light_id_map_.count(id) == 0) {
       return {};
     }
-    return std::make_shared<autoware_perception_msgs::msg::TrafficLightStateStamped>(traffic_light_id_map_.at(id));
+    return std::make_shared<autoware_perception_msgs::msg::TrafficLightStateStamped>(
+      traffic_light_id_map_.at(id));
   }
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/behavior_velocity_planner/planner_manager.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include <tf2_ros/transform_listener.h>
 #include <autoware_lanelet2_msgs/msg/map_bin.hpp>
 #include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
 #include <autoware_planning_msgs/msg/path.hpp>
@@ -27,7 +28,6 @@
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tf2_ros/transform_listener.h>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/manager.h
@@ -37,7 +37,7 @@
 class BlindSpotModuleManager : public SceneModuleManagerInterface
 {
 public:
-  BlindSpotModuleManager();
+  BlindSpotModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "blind_spot"; }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.h
@@ -71,14 +71,14 @@ public:
       state_ = State::GO;
       margin_time_ = 0.0;
     }
-    void setStateWithMarginTime(State state);
+    void setStateWithMarginTime(State state, rclcpp::Logger logger, rclcpp::Clock & clock);
     void setState(State state);
     void setMarginTime(const double t);
     State getState();
 
   private:
-    State state_;                            //! current state
-    double margin_time_;                     //! margin time when transit to Go from Stop
+    State state_;                               //! current state
+    double margin_time_;                        //! margin time when transit to Go from Stop
     std::shared_ptr<rclcpp::Time> start_time_;  //! first time received GO when STOP state
   };
 
@@ -107,7 +107,8 @@ public:
 
   BlindSpotModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   /**
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
@@ -201,8 +202,9 @@ private:
    * @return false when generation failed
    */
   bool generateStopLine(
-    const lanelet::ConstLanelets straight_lanelets, autoware_planning_msgs::msg::PathWithLaneId * path,
-    int * stop_line_idx, int * pass_judge_line_idx) const;
+    const lanelet::ConstLanelets straight_lanelets,
+    autoware_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx,
+    int * pass_judge_line_idx) const;
 
   /**
    * @brief Calculate first path index that is conflicting lanelets.

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/manager.h
@@ -33,7 +33,6 @@
 
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -50,7 +49,7 @@
 class CrosswalkModuleManager : public SceneModuleManagerInterface
 {
 public:
-  CrosswalkModuleManager();
+  CrosswalkModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "crosswalk"; }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.h
@@ -29,9 +29,9 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <pcl/common/distances.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -59,7 +59,8 @@ public:
 
   CrosswalkModule(
     const int64_t module_id, const lanelet::ConstLanelet & crosswalk,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(
     autoware_planning_msgs::msg::PathWithLaneId * path,

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_walkway.h
@@ -31,7 +31,6 @@
 
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -57,7 +56,8 @@ public:
   };
   WalkwayModule(
     const int64_t module_id, const lanelet::ConstLanelet & walkway,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(
     autoware_planning_msgs::msg::PathWithLaneId * path,

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/util.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/crosswalk/util.h
@@ -29,8 +29,8 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <behavior_velocity_planner/planner_data.h>
+#include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 
 struct DebugData
 {

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/manager.h
@@ -40,7 +40,7 @@
 class DetectionAreaModuleManager : public SceneModuleManagerInterface
 {
 public:
-  DetectionAreaModuleManager();
+  DetectionAreaModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "detection_area"; }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/detection_area/scene.h
@@ -59,7 +59,8 @@ public:
 public:
   DetectionAreaModule(
     const int64_t module_id, const lanelet::autoware::DetectionArea & detection_area_reg_elem,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(
     autoware_planning_msgs::msg::PathWithLaneId * path,
@@ -97,7 +98,8 @@ private:
     const double & margin, size_t & target_point_idx, Eigen::Vector2d & target_point);
 
   bool isOverDeadLine(
-    const geometry_msgs::msg::Pose & self_pose, const autoware_planning_msgs::msg::PathWithLaneId & input_path,
+    const geometry_msgs::msg::Pose & self_pose,
+    const autoware_planning_msgs::msg::PathWithLaneId & input_path,
     const size_t & dead_line_point_idx, const Eigen::Vector2d & dead_line_point,
     const double dead_line_range);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/manager.h
@@ -38,7 +38,7 @@
 class IntersectionModuleManager : public SceneModuleManagerInterface
 {
 public:
-  IntersectionModuleManager();
+  IntersectionModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "intersection"; }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.h
@@ -61,14 +61,14 @@ public:
       state_ = State::GO;
       margin_time_ = 0.0;
     }
-    void setStateWithMarginTime(State state);
+    void setStateWithMarginTime(State state, rclcpp::Logger logger, rclcpp::Clock & clock);
     void setState(State state);
     void setMarginTime(const double t);
     State getState();
 
   private:
-    State state_;                            //! current state
-    double margin_time_;                     //! margin time when transit to Go from Stop
+    State state_;                               //! current state
+    double margin_time_;                        //! margin time when transit to Go from Stop
     std::shared_ptr<rclcpp::Time> start_time_;  //! first time received GO when STOP state
   };
 
@@ -105,7 +105,8 @@ public:
 
   IntersectionModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   /**
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
@@ -148,7 +149,8 @@ private:
    * @return true if exists
    */
   bool checkStuckVehicleInIntersection(
-    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx, const int stop_idx,
+    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
+    const int stop_idx,
     const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr) const;
 
   /**
@@ -161,8 +163,8 @@ private:
    * @return generated polygon
    */
   Polygon2d generateEgoIntersectionLanePolygon(
-    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx, const int start_idx,
-    const double extra_dist, const double ignore_dist) const;
+    const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
+    const int start_idx, const double extra_dist, const double ignore_dist) const;
 
   /**
    * @brief Modify objects predicted path. remove path point if the time exceeds timer_thr.

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/scene_merge_from_private_road.h
@@ -68,14 +68,14 @@ public:
       state_ = State::GO;
       margin_time_ = 0.0;
     }
-    void setStateWithMarginTime(State state);
+    void setStateWithMarginTime(State state, rclcpp::Logger logger, rclcpp::Clock & clock);
     void setState(State state);
     void setMarginTime(const double t);
     State getState();
 
   private:
-    State state_;                            //! current state
-    double margin_time_;                     //! margin time when transit to Go from Stop
+    State state_;                               //! current state
+    double margin_time_;                        //! margin time when transit to Go from Stop
     std::shared_ptr<rclcpp::Time> start_time_;  //! first time received GO when STOP state
   };
 
@@ -98,7 +98,8 @@ public:
 public:
   MergeFromPrivateRoadModule(
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-    const IntersectionModule::PlannerParam & planner_param);
+    const IntersectionModule::PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   /**
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/util.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/intersection/util.h
@@ -37,7 +37,8 @@ bool splineInterpolate(
   autoware_planning_msgs::msg::PathWithLaneId * output);
 
 int insertPoint(
-  const geometry_msgs::msg::Pose & in_pose, autoware_planning_msgs::msg::PathWithLaneId * inout_path);
+  const geometry_msgs::msg::Pose & in_pose,
+  autoware_planning_msgs::msg::PathWithLaneId * inout_path);
 
 geometry_msgs::msg::Pose getAheadPose(
   const size_t start_idx, const double ahead_dist,
@@ -67,8 +68,8 @@ bool generateStopLine(
   const int lane_id, const std::vector<lanelet::CompoundPolygon3d> detection_areas,
   const std::shared_ptr<const PlannerData> & planner_data,
   const IntersectionModule::PlannerParam & planner_param,
-  autoware_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx, int * pass_judge_line_idx,
-  int * first_idx_inside_lane);
+  autoware_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx,
+  int * pass_judge_line_idx, int * first_idx_inside_lane);
 
 /**
    * @brief Calculate first path index that is in the polygon.

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/manager.h
@@ -40,7 +40,7 @@
 class StopLineModuleManager : public SceneModuleManagerInterface
 {
 public:
-  StopLineModuleManager();
+  StopLineModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "stop_line"; }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/stop_line/scene.h
@@ -27,6 +27,8 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <rclcpp/rclcpp.hpp>
+
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_extension/utility/query.h>
 #include <lanelet2_routing/RoutingGraph.h>
@@ -54,7 +56,8 @@ public:
 public:
   StopLineModule(
     const int64_t module_id, const lanelet::ConstLineString3d & stop_line,
-    const PlannerParam & planner_param);
+    const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(
     autoware_planning_msgs::msg::PathWithLaneId * path,

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/manager.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/manager.h
@@ -39,7 +39,7 @@
 class TrafficLightModuleManager : public SceneModuleManagerInterface
 {
 public:
-  TrafficLightModuleManager();
+  TrafficLightModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "traffic_light"; }
 
@@ -53,5 +53,6 @@ private:
     const autoware_planning_msgs::msg::PathWithLaneId & path) override;
 
   // Debug
-  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightStateStamped>::SharedPtr pub_tl_state_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightStateStamped>::SharedPtr
+    pub_tl_state_;
 };

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/scene_module/traffic_light/scene.h
@@ -45,7 +45,8 @@ public:
   {
     double base_link2front;
     std::vector<std::tuple<
-      std::shared_ptr<const lanelet::TrafficLight>, autoware_perception_msgs::msg::TrafficLightState>>
+      std::shared_ptr<const lanelet::TrafficLight>,
+      autoware_perception_msgs::msg::TrafficLightState>>
       tl_state;  // TODO: replace tuple with struct
     std::vector<geometry_msgs::msg::Pose> stop_poses;
     geometry_msgs::msg::Pose first_stop_pose;
@@ -62,7 +63,8 @@ public:
 public:
   TrafficLightModule(
     const int64_t module_id, const lanelet::TrafficLight & traffic_light_reg_elem,
-    lanelet::ConstLanelet lane, const PlannerParam & planner_param);
+    lanelet::ConstLanelet lane, const PlannerParam & planner_param, const rclcpp::Logger logger,
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(
     autoware_planning_msgs::msg::PathWithLaneId * path,
@@ -97,8 +99,9 @@ private:
 
   bool isOverDeadLine(
     const geometry_msgs::msg::Pose & self_pose,
-    const autoware_planning_msgs::msg::PathWithLaneId & input_path, const size_t & dead_line_point_idx,
-    const Eigen::Vector2d & dead_line_point, const double dead_line_range);
+    const autoware_planning_msgs::msg::PathWithLaneId & input_path,
+    const size_t & dead_line_point_idx, const Eigen::Vector2d & dead_line_point,
+    const double dead_line_range);
 
   bool isStopRequired(const autoware_perception_msgs::msg::TrafficLightState & tl_state);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/boost_geometry_helper.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/boost_geometry_helper.h
@@ -30,10 +30,10 @@
 #include <boost/geometry/geometries/register/point.hpp>
 #include <boost/geometry/geometries/segment.hpp>
 
+#include <tf2/utils.h>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <tf2/utils.h>
 
 #include <autoware_planning_msgs/msg/path_point.hpp>
 #include <autoware_planning_msgs/msg/path_point_with_lane_id.hpp>
@@ -57,8 +57,8 @@ BOOST_GEOMETRY_REGISTER_POINT_3D(
   autoware_planning_msgs::msg::PathPointWithLaneId, double, cs::cartesian, point.pose.position.x,
   point.pose.position.y, point.pose.position.z)
 BOOST_GEOMETRY_REGISTER_POINT_3D(
-  autoware_planning_msgs::msg::TrajectoryPoint, double, cs::cartesian, pose.position.x, pose.position.y,
-  pose.position.z)
+  autoware_planning_msgs::msg::TrajectoryPoint, double, cs::cartesian, pose.position.x,
+  pose.position.y, pose.position.z)
 
 template <class T>
 Point2d to_bg2d(const T & p)
@@ -104,7 +104,8 @@ inline Polygon2d lines2polygon(const LineString2d & left_line, const LineString2
   return polygon;
 }
 
-inline Polygon2d obj2polygon(const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & shape)
+inline Polygon2d obj2polygon(
+  const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & shape)
 {
   //rename
   const double x = pose.position.x;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/marker_helper.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/marker_helper.h
@@ -28,7 +28,8 @@ inline geometry_msgs::msg::Point createMarkerPosition(double x, double y, double
   return point;
 }
 
-inline geometry_msgs::msg::Quaternion createMarkerOrientation(double x, double y, double z, double w)
+inline geometry_msgs::msg::Quaternion createMarkerOrientation(
+  double x, double y, double z, double w)
 {
   geometry_msgs::msg::Quaternion quaternion;
 
@@ -63,34 +64,13 @@ inline std_msgs::msg::ColorRGBA createMarkerColor(float r, float g, float b, flo
   return color;
 }
 
-inline visualization_msgs::msg::Marker createDefaultMarker(
-  const char * frame_id, const char * ns, const int32_t id, const int32_t type,
-  const std_msgs::msg::ColorRGBA & color)
-{
-  visualization_msgs::msg::Marker marker;
-
-  marker.header.frame_id = frame_id;
-  marker.header.stamp = this->now();
-  marker.ns = ns;
-  marker.id = id;
-  marker.type = type;
-  marker.action = visualization_msgs::msg::Marker::ADD;
-  marker.lifetime = rclcpp::Duration(0);
-
-  marker.pose.position = createMarkerPosition(0.0, 0.0, 0.0);
-  marker.pose.orientation = createMarkerOrientation(0.0, 0.0, 0.0, 1.0);
-  marker.scale = createMarkerScale(1.0, 1.0, 1.0);
-  marker.color = color;
-  marker.frame_locked = true;
-
-  return marker;
-}
-
 inline void appendMarkerArray(
   const visualization_msgs::msg::MarkerArray & additional_marker_array,
+  const builtin_interfaces::msg::Time current_time,
   visualization_msgs::msg::MarkerArray * marker_array)
 {
   for (const auto & marker : additional_marker_array.markers) {
     marker_array->markers.push_back(marker);
+    marker_array->markers.back().header.stamp = current_time;
   }
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/path_utilization.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/path_utilization.h
@@ -15,9 +15,14 @@
  */
 #pragma once
 
+#include <rclcpp/rclcpp.hpp>
+
 #include <autoware_planning_msgs/msg/path.hpp>
 
 autoware_planning_msgs::msg::Path interpolatePath(
-  const autoware_planning_msgs::msg::Path & path, const double length);
-autoware_planning_msgs::msg::Path filterLitterPathPoint(const autoware_planning_msgs::msg::Path & path);
-autoware_planning_msgs::msg::Path filterStopPathPoint(const autoware_planning_msgs::msg::Path & path);
+  const autoware_planning_msgs::msg::Path & path, const double length,
+  const rclcpp::Logger & logger);
+autoware_planning_msgs::msg::Path filterLitterPathPoint(
+  const autoware_planning_msgs::msg::Path & path);
+autoware_planning_msgs::msg::Path filterStopPathPoint(
+  const autoware_planning_msgs::msg::Path & path);

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/util.h
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/include/utilization/util.h
@@ -18,21 +18,21 @@
 #ifndef COMMON_MATH_PLANNING_UTILS_H
 #define COMMON_MATH_PLANNING_UTILS_H
 
+#include <pcl/point_types.h>
+#include <tf2/utils.h>
 #include <autoware_perception_msgs/msg/dynamic_object_array.hpp>
 #include <autoware_planning_msgs/msg/path.hpp>
 #include <autoware_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_planning_msgs/msg/stop_reason.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
-#include <geometry_msgs/msg/pose_stamped.hpp>
-#include <geometry_msgs/msg/quaternion.hpp>
-#include <pcl_ros/point_cloud.h>
-#include <tf2/utils.h>
-#include <visualization_msgs/msg/marker.hpp>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
 #include <vector>
+#include <visualization_msgs/msg/marker.hpp>
 
 using Point2d = boost::geometry::model::d2::point_xy<double>;
 namespace planning_utils
@@ -47,7 +47,8 @@ inline geometry_msgs::msg::Point getPoint(const autoware_planning_msgs::msg::Pat
 {
   return p.pose.position;
 }
-inline geometry_msgs::msg::Point getPoint(const autoware_planning_msgs::msg::PathPointWithLaneId & p)
+inline geometry_msgs::msg::Point getPoint(
+  const autoware_planning_msgs::msg::PathPointWithLaneId & p)
 {
   return p.point.pose.position;
 }
@@ -59,11 +60,13 @@ inline geometry_msgs::msg::Pose getPose(const autoware_planning_msgs::msg::Path 
 {
   return path.points.at(idx).pose;
 }
-inline geometry_msgs::msg::Pose getPose(const autoware_planning_msgs::msg::PathWithLaneId & path, int idx)
+inline geometry_msgs::msg::Pose getPose(
+  const autoware_planning_msgs::msg::PathWithLaneId & path, int idx)
 {
   return path.points.at(idx).point.pose;
 }
-inline geometry_msgs::msg::Pose getPose(const autoware_planning_msgs::msg::Trajectory & traj, int idx)
+inline geometry_msgs::msg::Pose getPose(
+  const autoware_planning_msgs::msg::Trajectory & traj, int idx)
 {
   return traj.points.at(idx).pose;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/package.xml
@@ -14,6 +14,7 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>eigen</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>rclcpp</depend>
@@ -24,6 +25,7 @@
   <depend>tf2_ros</depend>
   <depend>tf2_eigen</depend>
   <depend>pcl_conversions</depend>
+  <depend>vehicle_info_util</depend>
   <depend>visualization_msgs</depend>
 
   <export>

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/node.cpp
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+#include <functional>
+
 #include <behavior_velocity_planner/node.h>
 
-#include <pcl_ros/transforms.h>
+#include <pcl/common/transforms.h>
 #include <tf2_eigen/tf2_eigen.h>
 
 #include <lanelet2_extension/utility/message_conversion.h>
@@ -30,71 +32,15 @@
 // Scene modules
 #include <scene_module/blind_spot/manager.h>
 #include <scene_module/crosswalk/manager.h>
+#include <scene_module/detection_area/manager.h>
 #include <scene_module/intersection/manager.h>
 #include <scene_module/stop_line/manager.h>
 #include <scene_module/traffic_light/manager.h>
-#include <scene_module/detection_area/manager.h>
 
 namespace
 {
-template <class T>
-T getParam(const rclcpp::NodeHandle & nh, const std::string & key, const T & default_value)
-{
-  T value;
-  nh.param<T>(key, value, default_value);
-  return value;
-}
-
-template <class T>
-T waitForParam(const rclcpp::NodeHandle & nh, const std::string & key)
-{
-  T value;
-
-  rclcpp::Rate rate(1.0);
-  while (rclcpp::ok()) {
-    const auto result = nh.getParam(key, value);
-    if (result) {
-      return value;
-    }
-
-    ROS_INFO("waiting for parameter `%s` ...", key.c_str());
-    rate.sleep();
-  }
-
-  return {};
-}
-
-std::shared_ptr<geometry_msgs::msg::TransformStamped> getTransform(
-  const tf2_ros::Buffer & tf_buffer, const std::string & from, const std::string & to,
-  const rclcpp::Time & time = rclcpp::Time(0), const rclcpp::Duration & duration = rclcpp::Duration(0.1))
-{
-  try {
-    return std::make_shared<geometry_msgs::msg::TransformStamped>(
-      tf_buffer.lookupTransform(from, to, time, duration));
-  } catch (tf2::TransformException & ex) {
-    return {};
-  }
-}
-
-geometry_msgs::msg::TransformStamped waitForTransform(
-  const tf2_ros::Buffer & tf_buffer, const std::string & from, const std::string & to,
-  const rclcpp::Time & time = rclcpp::Time(0), const rclcpp::Duration & duration = rclcpp::Duration(0.1))
-{
-  rclcpp::Rate rate(1.0);
-  while (rclcpp::ok()) {
-    const auto transform = getTransform(tf_buffer, from, to, time, duration);
-    if (transform) {
-      return *transform;
-    }
-
-    ROS_INFO(
-      "waiting for transform from `%s` to `%s` ... (time = %f, now = %f)", from.c_str(), to.c_str(),
-      time.toSec(), this->now().toSec());
-    rate.sleep();
-  }
-}
-
-geometry_msgs::msg::PoseStamped transform2pose(const geometry_msgs::msg::TransformStamped & transform)
+geometry_msgs::msg::PoseStamped transform2pose(
+  const geometry_msgs::msg::TransformStamped & transform)
 {
   geometry_msgs::msg::PoseStamped pose;
   pose.header = transform.header;
@@ -105,7 +51,8 @@ geometry_msgs::msg::PoseStamped transform2pose(const geometry_msgs::msg::Transfo
   return pose;
 }
 
-autoware_planning_msgs::msg::Path to_path(const autoware_planning_msgs::msg::PathWithLaneId & path_with_id)
+autoware_planning_msgs::msg::Path to_path(
+  const autoware_planning_msgs::msg::PathWithLaneId & path_with_id)
 {
   autoware_planning_msgs::msg::Path path;
   for (const auto & path_point : path_with_id.points) {
@@ -116,19 +63,34 @@ autoware_planning_msgs::msg::Path to_path(const autoware_planning_msgs::msg::Pat
 }  // namespace
 
 BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode()
-: nh_(), pnh_("~"), tf_listener_(tf_buffer_)
+: Node("behavior_velocity_planner_node"),
+  tf_buffer_(this->get_clock()),
+  tf_listener_(tf_buffer_),
+  planner_data_(*this)
 {
+  using std::placeholders::_1;
   // Trigger Subscriber
   trigger_sub_path_with_lane_id_ =
-    this->create_subscription<TODO>("input/path_with_lane_id", 1, &BehaviorVelocityPlannerNode::onTrigger, this);
+    this->create_subscription<autoware_planning_msgs::msg::PathWithLaneId>(
+      "input/path_with_lane_id", 1, std::bind(&BehaviorVelocityPlannerNode::onTrigger, this, _1));
 
   // Subscribers
-  sub_dynamic_objects_ = this->create_subscription<TODO>("input/dynamic_objects", 1, &BehaviorVelocityPlannerNode::onDynamicObjects, this);
-  sub_no_ground_pointcloud_ = this->create_subscription<TODO>("input/no_ground_pointcloud", 1, &BehaviorVelocityPlannerNode::onNoGroundPointCloud, this);
-  sub_vehicle_velocity_ = this->create_subscription<TODO>("input/vehicle_velocity", 1, &BehaviorVelocityPlannerNode::onVehicleVelocity, this);
-  sub_lanelet_map_ =
-    this->create_subscription<TODO>("input/vector_map", 10, &BehaviorVelocityPlannerNode::onLaneletMap, this);
-  sub_traffic_light_states_ = this->create_subscription<TODO>("input/traffic_light_states", 10, &BehaviorVelocityPlannerNode::onTrafficLightStates, this);
+  sub_dynamic_objects_ =
+    this->create_subscription<autoware_perception_msgs::msg::DynamicObjectArray>(
+      "input/dynamic_objects", 1,
+      std::bind(&BehaviorVelocityPlannerNode::onDynamicObjects, this, _1));
+  sub_no_ground_pointcloud_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
+    "input/no_ground_pointcloud", 1,
+    std::bind(&BehaviorVelocityPlannerNode::onNoGroundPointCloud, this, _1));
+  sub_vehicle_velocity_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+    "input/vehicle_velocity", 1,
+    std::bind(&BehaviorVelocityPlannerNode::onVehicleVelocity, this, _1));
+  sub_lanelet_map_ = this->create_subscription<autoware_lanelet2_msgs::msg::MapBin>(
+    "input/vector_map", 10, std::bind(&BehaviorVelocityPlannerNode::onLaneletMap, this, _1));
+  sub_traffic_light_states_ =
+    this->create_subscription<autoware_perception_msgs::msg::TrafficLightStateArray>(
+      "input/traffic_light_states", 10,
+      std::bind(&BehaviorVelocityPlannerNode::onTrafficLightStates, this, _1));
 
   // Publishers
   path_pub_ = this->create_publisher<autoware_planning_msgs::msg::Path>("output/path", 1);
@@ -137,39 +99,22 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode()
   debug_viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("debug/path", 1);
 
   // Parameters
-  pnh_.param("forward_path_length", forward_path_length_, 1000.0);
-  pnh_.param("backward_path_length", backward_path_length_, 5.0);
-
-  // Vehicle Parameters
-  planner_data_.wheel_base = waitForParam<double>(pnh_, "/vehicle_info/wheel_base");
-  planner_data_.front_overhang = waitForParam<double>(pnh_, "/vehicle_info/front_overhang");
-  planner_data_.vehicle_width = waitForParam<double>(pnh_, "/vehicle_info/vehicle_width");
-  // Additional Vehicle Parameters
-  pnh_.param(
-    "max_accel", planner_data_.max_stop_acceleration_threshold_,
-    -5.0);  // TODO read min_acc in velocity_controller_param.yaml?
-  pnh_.param("delay_response_time", planner_data_.delay_response_time_, 1.3);
-  // TODO(Kenji Miyake): get from additional vehicle_info?
-  planner_data_.base_link2front = planner_data_.front_overhang + planner_data_.wheel_base;
+  forward_path_length_ = this->declare_parameter("forward_path_length", 1000.0);
+  backward_path_length_ = this->declare_parameter("backward_path_length", 5.0);
 
   // Initialize PlannerManager
-  if (getParam<bool>(pnh_, "launch_stop_line", true))
-    planner_manager_.launchSceneModule(std::make_shared<StopLineModuleManager>());
-  if (getParam<bool>(pnh_, "launch_crosswalk", true))
-    planner_manager_.launchSceneModule(std::make_shared<CrosswalkModuleManager>());
-  if (getParam<bool>(pnh_, "launch_traffic_light", true))
-    planner_manager_.launchSceneModule(std::make_shared<TrafficLightModuleManager>());
-  if (getParam<bool>(pnh_, "launch_intersection", true))
-    planner_manager_.launchSceneModule(std::make_shared<IntersectionModuleManager>());
-  if (getParam<bool>(pnh_, "launch_blind_spot", true))
-    planner_manager_.launchSceneModule(std::make_shared<BlindSpotModuleManager>());
-  if (getParam<bool>(pnh_, "launch_detection_area", true))
-    planner_manager_.launchSceneModule(std::make_shared<DetectionAreaModuleManager>());
-}
-
-geometry_msgs::msg::PoseStamped BehaviorVelocityPlannerNode::getCurrentPose()
-{
-  return transform2pose(waitForTransform(tf_buffer_, "map", "base_link"));
+  if (this->declare_parameter("launch_stop_line", true))
+    planner_manager_.launchSceneModule(std::make_shared<StopLineModuleManager>(*this));
+  if (this->declare_parameter("launch_crosswalk", true))
+    planner_manager_.launchSceneModule(std::make_shared<CrosswalkModuleManager>(*this));
+  if (this->declare_parameter("launch_traffic_light", true))
+    planner_manager_.launchSceneModule(std::make_shared<TrafficLightModuleManager>(*this));
+  if (this->declare_parameter("launch_intersection", true))
+    planner_manager_.launchSceneModule(std::make_shared<IntersectionModuleManager>(*this));
+  if (this->declare_parameter("launch_blind_spot", true))
+    planner_manager_.launchSceneModule(std::make_shared<BlindSpotModuleManager>(*this));
+  if (this->declare_parameter("launch_detection_area", true))
+    planner_manager_.launchSceneModule(std::make_shared<DetectionAreaModuleManager>(*this));
 }
 
 bool BehaviorVelocityPlannerNode::isDataReady()
@@ -189,39 +134,41 @@ bool BehaviorVelocityPlannerNode::isDataReady()
 }
 
 void BehaviorVelocityPlannerNode::onDynamicObjects(
-  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & msg)
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr msg)
 {
   planner_data_.dynamic_objects = msg;
 }
 
 void BehaviorVelocityPlannerNode::onNoGroundPointCloud(
-  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
-  const auto transform =
-    getTransform(tf_buffer_, "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration(0.1));
-  if (!transform) {
-    ROS_WARN("no transform found for no_ground_pointcloud");
+  geometry_msgs::msg::TransformStamped transform;
+  try {
+    transform = tf_buffer_.lookupTransform(
+      "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration(0.1));
+  } catch (tf2::LookupException & e) {
+    RCLCPP_WARN(get_logger(), "no transform found for no_ground_pointcloud");
     return;
   }
 
-  pcl::PointCloud<pcl::PointXYZ>::Ptr no_ground_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::PointCloud<pcl::PointXYZ> pc;
+  pcl::fromROSMsg(*msg, pc);
 
-  Eigen::Matrix4f affine = tf2::transformToEigen(transform->transform).matrix().cast<float>();
-  sensor_msgs::msg::PointCloud2 transformed_msg;
-  pcl_ros::transformPointCloud(affine, *msg, transformed_msg);
+  Eigen::Affine3f affine = tf2::transformToEigen(transform.transform).cast<float>();
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pc_transformed(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::transformPointCloud(pc, *pc_transformed, affine);
 
-  pcl::fromROSMsg(transformed_msg, *no_ground_pointcloud);
-
-  planner_data_.no_ground_pointcloud = no_ground_pointcloud;
+  planner_data_.no_ground_pointcloud = pc_transformed;
 }
 
 void BehaviorVelocityPlannerNode::onVehicleVelocity(
-  const geometry_msgs::msg::TwistStamped::ConstSharedPtr & msg)
+  const geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
 {
   planner_data_.current_velocity = msg;
 }
 
-void BehaviorVelocityPlannerNode::onLaneletMap(const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr & msg)
+void BehaviorVelocityPlannerNode::onLaneletMap(
+  const autoware_lanelet2_msgs::msg::MapBin::ConstSharedPtr msg)
 {
   // Load map
   planner_data_.lanelet_map = std::make_shared<lanelet::LaneletMap>();
@@ -253,7 +200,7 @@ void BehaviorVelocityPlannerNode::onLaneletMap(const autoware_lanelet2_msgs::msg
 }
 
 void BehaviorVelocityPlannerNode::onTrafficLightStates(
-  const autoware_perception_msgs::msg::TrafficLightStateArray::ConstSharedPtr & msg)
+  const autoware_perception_msgs::msg::TrafficLightStateArray::ConstSharedPtr msg)
 {
   for (const auto & state : msg->states) {
     autoware_perception_msgs::msg::TrafficLightStateStamped traffic_light_state;
@@ -264,23 +211,31 @@ void BehaviorVelocityPlannerNode::onTrafficLightStates(
 }
 
 void BehaviorVelocityPlannerNode::onTrigger(
-  const autoware_planning_msgs::msg::PathWithLaneId & input_path_msg)
+  const autoware_planning_msgs::msg::PathWithLaneId::ConstSharedPtr input_path_msg)
 {
   // Check ready
-  planner_data_.current_pose = getCurrentPose();
+  try {
+    planner_data_.current_pose =
+      transform2pose(tf_buffer_.lookupTransform("map", "base_link", tf2::TimePointZero));
+  } catch (tf2::LookupException & e) {
+    RCLCPP_INFO(get_logger(), "waiting for transform from `map` to `base_link`");
+    return;
+  }
+
   if (!isDataReady()) {
     return;
   }
 
   // Plan path velocity
   const auto velocity_planned_path = planner_manager_.planPathVelocity(
-    std::make_shared<const PlannerData>(planner_data_), input_path_msg);
+    std::make_shared<const PlannerData>(planner_data_), *input_path_msg);
 
   // screening
   const auto filtered_path = filterLitterPathPoint(to_path(velocity_planned_path));
 
   // interpolation
-  const auto interpolated_path_msg = interpolatePath(filtered_path, forward_path_length_);
+  const auto interpolated_path_msg =
+    interpolatePath(filtered_path, forward_path_length_, this->get_logger());
 
   // check stop point
   auto output_path_msg = filterStopPathPoint(interpolated_path_msg);
@@ -288,20 +243,20 @@ void BehaviorVelocityPlannerNode::onTrigger(
   output_path_msg.header.stamp = this->now();
 
   // TODO: This must be updated in each scene module, but copy from input message for now.
-  output_path_msg.drivable_area = input_path_msg.drivable_area;
+  output_path_msg.drivable_area = input_path_msg->drivable_area;
 
   path_pub_->publish(output_path_msg);
-  stop_reason_diag_pub_.publish(planner_manager_.getStopReasonDiag());
-  publishDebugMarker(output_path_msg, debug_viz_pub_);
+  stop_reason_diag_pub_->publish(planner_manager_.getStopReasonDiag());
+
+  if (debug_viz_pub_->get_subscription_count() > 0) {
+    publishDebugMarker(output_path_msg);
+  }
 
   return;
-};
+}
 
-void BehaviorVelocityPlannerNode::publishDebugMarker(
-  const autoware_planning_msgs::msg::Path & path, const rclcpp::Publisher & pub)
+void BehaviorVelocityPlannerNode::publishDebugMarker(const autoware_planning_msgs::msg::Path & path)
 {
-  if (pub.getNumSubscribers() < 1) return;
-
   visualization_msgs::msg::MarkerArray output_msg;
   for (size_t i = 0; i < path.points.size(); ++i) {
     visualization_msgs::msg::Marker marker;
@@ -319,5 +274,5 @@ void BehaviorVelocityPlannerNode::publishDebugMarker(
     marker.color.b = 1.0;
     output_msg.markers.push_back(marker);
   }
-  pub->publish(output_msg);
+  debug_viz_pub_->publish(output_msg);
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -31,8 +31,11 @@ namespace bg = boost::geometry;
 
 BlindSpotModule::BlindSpotModule(
   const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-  const PlannerParam & planner_param)
-: SceneModuleInterface(module_id), lane_id_(lane_id), turn_direction_(TurnDirection::INVALID)
+  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock),
+  lane_id_(lane_id),
+  turn_direction_(TurnDirection::INVALID)
 {
   planner_param_ = planner_param;
   const auto & assigned_lanelet = planner_data->lanelet_map->laneletLayer.get(lane_id);
@@ -47,7 +50,8 @@ BlindSpotModule::BlindSpotModule(
 }
 
 bool BlindSpotModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   debug_data_ = {};
   *stop_reason =
@@ -57,7 +61,8 @@ bool BlindSpotModule::modifyPathVelocity(
   debug_data_.path_raw = input_path;
 
   State current_state = state_machine_.getState();
-  ROS_DEBUG("[Blind Spot] lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
+  RCLCPP_DEBUG(
+    logger_, "[Blind Spot] lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
 
   /* get current pose */
   geometry_msgs::msg::PoseStamped current_pose = planner_data_->current_pose;
@@ -71,25 +76,27 @@ bool BlindSpotModule::modifyPathVelocity(
   int pass_judge_line_idx = -1;
   const auto straight_lanelets = getStraightLanelets(lanelet_map_ptr, routing_graph_ptr, lane_id_);
   if (!generateStopLine(straight_lanelets, path, &stop_line_idx, &pass_judge_line_idx)) {
-    ROS_WARN_DELAYED_THROTTLE(1.0, "[BlindSpotModule::run] setStopLineIdx fail");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(
+      logger_, *clock_, 1.0, "[BlindSpotModule::run] setStopLineIdx fail");
     return false;
   }
 
   if (stop_line_idx <= 0 || pass_judge_line_idx <= 0) {
-    ROS_DEBUG("[Blind Spot] stop line or pass judge line is at path[0], ignore planning.");
+    RCLCPP_DEBUG(
+      logger_, "[Blind Spot] stop line or pass judge line is at path[0], ignore planning.");
     return true;
   }
 
   /* calc closest index */
   int closest_idx = -1;
   if (!planning_utils::calcClosestIndex(input_path, current_pose.pose, closest_idx)) {
-    ROS_WARN_DELAYED_THROTTLE(1.0, "[Blind Spot] calcClosestIndex fail");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1.0, "[Blind Spot] calcClosestIndex fail");
     return false;
   }
 
   /* get debug info */
-  debug_data_.virtual_wall_pose =
-    util::getAheadPose(stop_line_idx, planner_data_->base_link2front, *path);
+  debug_data_.virtual_wall_pose = util::getAheadPose(
+    stop_line_idx, planner_data_->vehicle_info_.max_longitudinal_offset_m_, *path);
   debug_data_.stop_point_pose = path->points.at(stop_line_idx).point.pose;
   debug_data_.judge_point_pose = path->points.at(pass_judge_line_idx).point.pose;
 
@@ -100,7 +107,7 @@ bool BlindSpotModule::modifyPathVelocity(
     is_over_pass_judge_line = util::isAheadOf(current_pose.pose, pass_judge_line);
   }
   if (current_state == State::GO && is_over_pass_judge_line) {
-    ROS_DEBUG("[Blind Spot] over the pass judge line. no plan needed.");
+    RCLCPP_DEBUG(logger_, "[Blind Spot] over the pass judge line. no plan needed.");
     return true;  // no plan needed.
   }
 
@@ -110,7 +117,7 @@ bool BlindSpotModule::modifyPathVelocity(
   /* calculate dynamic collision around detection area */
   bool has_obstacle =
     checkObstacleInBlindSpot(lanelet_map_ptr, routing_graph_ptr, *path, objects_ptr, closest_idx);
-  state_machine_.setStateWithMarginTime(has_obstacle ? State::STOP : State::GO);
+  state_machine_.setStateWithMarginTime(has_obstacle ? State::STOP : State::GO, logger_, *clock_);
 
   /* set stop speed */
   if (state_machine_.getState() == State::STOP) {
@@ -138,7 +145,8 @@ boost::optional<int> BlindSpotModule::getFirstPointConflictingLanelets(
     const auto line = (turn_direction_ == TurnDirection::LEFT) ? ll.leftBound() : ll.rightBound();
     for (size_t i = 0; i < path.points.size(); ++i) {
       const auto vehicle_edge = getVehicleEdge(
-        path.points.at(i).point.pose, planner_data_->vehicle_width, planner_data_->base_link2front);
+        path.points.at(i).point.pose, planner_data_->vehicle_info_.vehicle_width_m_,
+        planner_data_->vehicle_info_.max_longitudinal_offset_m_);
       if (bg::intersects(toHybrid(to2D(line)), toHybrid(vehicle_edge))) {
         first_idx_conflicting_lanelets =
           std::min(first_idx_conflicting_lanelets, static_cast<int>(i));
@@ -155,8 +163,9 @@ boost::optional<int> BlindSpotModule::getFirstPointConflictingLanelets(
 }
 
 bool BlindSpotModule::generateStopLine(
-  const lanelet::ConstLanelets straight_lanelets, autoware_planning_msgs::msg::PathWithLaneId * path,
-  int * stop_line_idx, int * pass_judge_line_idx) const
+  const lanelet::ConstLanelets straight_lanelets,
+  autoware_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx,
+  int * pass_judge_line_idx) const
 {
   /* set judge line dist */
   const double current_vel = planner_data_->current_velocity->twist.linear.x;
@@ -168,7 +177,8 @@ bool BlindSpotModule::generateStopLine(
   /* set parameters */
   constexpr double interval = 0.2;
   const int margin_idx_dist = std::ceil(planner_param_.stop_line_margin / interval);
-  const int base2front_idx_dist = std::ceil(planner_data_->base_link2front / interval);
+  const int base2front_idx_dist =
+    std::ceil(planner_data_->vehicle_info_.max_longitudinal_offset_m_ / interval);
   const int pass_judge_idx_dist = std::ceil(pass_judge_line_dist / interval);
 
   /* spline interpolation */
@@ -182,7 +192,7 @@ bool BlindSpotModule::generateStopLine(
     boost::optional<int> first_idx_conflicting_lane_opt =
       getFirstPointConflictingLanelets(path_ip, straight_lanelets);
     if (!first_idx_conflicting_lane_opt) {
-      ROS_DEBUG("No conflicting line found.");
+      RCLCPP_DEBUG(logger_, "No conflicting line found.");
       return false;
     }
     stop_idx_ip =
@@ -191,7 +201,7 @@ bool BlindSpotModule::generateStopLine(
     boost::optional<geometry_msgs::msg::Point> intersection_enter_point_opt =
       getStartPointFromLaneLet(lane_id_);
     if (!intersection_enter_point_opt) {
-      ROS_DEBUG("No intersection enter point found.");
+      RCLCPP_DEBUG(logger_, "No intersection enter point found.");
       return false;
     }
     planning_utils::calcClosestIndex(
@@ -222,7 +232,8 @@ bool BlindSpotModule::generateStopLine(
     ++(*stop_line_idx);  // stop index is incremented by judge line insertion
   }
 
-  ROS_DEBUG(
+  RCLCPP_DEBUG(
+    logger_,
     "[Blind Spot] generateStopLine() : stop_idx = %d, pass_judge_idx = %d, stop_idx_ip = %d, "
     "pass_judge_idx_ip = %d, has_prior_stopline = %d",
     *stop_line_idx, *pass_judge_line_idx, stop_idx_ip, pass_judge_idx_ip, has_prior_stopline);
@@ -233,12 +244,12 @@ bool BlindSpotModule::generateStopLine(
 void BlindSpotModule::cutPredictPathWithDuration(
   autoware_perception_msgs::msg::DynamicObjectArray * objects_ptr, const double time_thr) const
 {
-  const rclcpp::Time current_time = this->now();
+  const rclcpp::Time current_time = clock_->now();
   for (auto & object : objects_ptr->objects) {                    // each objects
     for (auto & predicted_path : object.state.predicted_paths) {  // each predicted paths
       std::vector<geometry_msgs::msg::PoseWithCovarianceStamped> vp;
       for (auto & predicted_pose : predicted_path.path) {  // each path points
-        if ((predicted_pose.header.stamp - current_time).toSec() < time_thr) {
+        if ((rclcpp::Time(predicted_pose.header.stamp) - current_time).seconds() < time_thr) {
           vp.push_back(predicted_pose);
         }
       }
@@ -255,7 +266,7 @@ bool BlindSpotModule::checkObstacleInBlindSpot(
 {
   /* get detection area */
   if (turn_direction_ == TurnDirection::INVALID) {
-    ROS_WARN("blind spot detector is running, turn_direction_ = not right or left.");
+    RCLCPP_WARN(logger_, "blind spot detector is running, turn_direction_ = not right or left.");
     return false;
   }
 
@@ -455,7 +466,8 @@ lanelet::ConstLanelets BlindSpotModule::getStraightLanelets(
   return straight_lanelets;
 }
 
-void BlindSpotModule::StateMachine::setStateWithMarginTime(State state)
+void BlindSpotModule::StateMachine::setStateWithMarginTime(
+  State state, rclcpp::Logger logger, rclcpp::Clock & clock)
 {
   /* same state request */
   if (state_ == state) {
@@ -473,9 +485,9 @@ void BlindSpotModule::StateMachine::setStateWithMarginTime(State state)
   /* STOP -> GO */
   if (state == State::GO) {
     if (start_time_ == nullptr) {
-      start_time_ = std::make_shared<rclcpp::Time>(this->now());
+      start_time_ = std::make_shared<rclcpp::Time>(clock.now());
     } else {
-      const double duration = (this->now() - *start_time_).toSec();
+      const double duration = (clock.now() - *start_time_).seconds();
       if (duration > margin_time_) {
         state_ = State::GO;
         start_time_ = nullptr;  // reset timer
@@ -484,7 +496,7 @@ void BlindSpotModule::StateMachine::setStateWithMarginTime(State state)
     return;
   }
 
-  ROS_ERROR("[StateMachine] : Unsuitable state. ignore request.");
+  RCLCPP_ERROR(logger, "[StateMachine] : Unsuitable state. ignore request.");
   return;
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/debug.cpp
@@ -25,7 +25,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   const DebugData & debug_data, const int64_t module_id)
 {
   visualization_msgs::msg::MarkerArray msg;
-  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -36,7 +35,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
 
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
 
     marker.ns = "crosswalk polygon line";
     marker.id = uid + i;
@@ -97,7 +95,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   for (size_t i = 0; i < debug_data.collision_lines.size(); ++i) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "collision line";
     marker.id = uid + i;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -129,7 +126,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   if (!debug_data.collision_points.empty()) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "collision point";
     marker.id = 0;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -164,7 +160,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
 
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
 
     marker.ns = "slow polygon line";
     marker.id = uid + i;
@@ -198,7 +193,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   if (!debug_data.slow_poses.empty()) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "slow point";
     marker.id = 0;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -233,7 +227,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
 
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
 
     marker.ns = "stop polygon line";
     marker.id = uid + i;
@@ -267,7 +260,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   if (!debug_data.stop_poses.empty()) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop point";
     marker.id = module_id;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -300,7 +292,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -324,7 +315,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -350,7 +340,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   for (size_t j = 0; j < debug_data.slow_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "slow virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -374,7 +363,6 @@ visualization_msgs::msg::MarkerArray createCrosswalkMarkers(
   for (size_t j = 0; j < debug_data.slow_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "slow factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -404,7 +392,6 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
 {
   int32_t uid = planning_utils::bitShift(module_id);
   visualization_msgs::msg::MarkerArray msg;
-  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -412,7 +399,6 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
   if (!debug_data.stop_poses.empty()) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop point";
     marker.id = module_id;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -445,7 +431,6 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -469,7 +454,6 @@ visualization_msgs::msg::MarkerArray createWalkwayMarkers(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -500,7 +484,8 @@ visualization_msgs::msg::MarkerArray CrosswalkModule::createDebugMarkerArray()
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
-  appendMarkerArray(createCrosswalkMarkers(debug_data_, module_id_), &debug_marker_array);
+  appendMarkerArray(
+    createCrosswalkMarkers(debug_data_, module_id_), this->clock_->now(), &debug_marker_array);
 
   return debug_marker_array;
 }
@@ -509,7 +494,8 @@ visualization_msgs::msg::MarkerArray WalkwayModule::createDebugMarkerArray()
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
-  appendMarkerArray(createWalkwayMarkers(debug_data_, module_id_), &debug_marker_array);
+  appendMarkerArray(
+    createWalkwayMarkers(debug_data_, module_id_), this->clock_->now(), &debug_marker_array);
 
   return debug_marker_array;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/manager.cpp
@@ -18,7 +18,8 @@
 namespace
 {
 std::vector<lanelet::ConstLanelet> getCrosswalksOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map,
   const std::shared_ptr<const lanelet::routing::RoutingGraphContainer> & overall_graphs)
 {
   std::vector<lanelet::ConstLanelet> crosswalks;
@@ -37,7 +38,8 @@ std::vector<lanelet::ConstLanelet> getCrosswalksOnPath(
 }
 
 std::set<int64_t> getCrosswalkIdSetOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map,
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map,
   const std::shared_ptr<const lanelet::routing::RoutingGraphContainer> & overall_graphs)
 {
   std::set<int64_t> crosswalk_id_set;
@@ -51,38 +53,37 @@ std::set<int64_t> getCrosswalkIdSetOnPath(
 
 }  // namespace
 
-CrosswalkModuleManager::CrosswalkModuleManager() : SceneModuleManagerInterface(getModuleName())
+CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
+: SceneModuleManagerInterface(node, getModuleName())
 {
-  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
 
   // for crosswalk parameters
   auto & cp = crosswalk_planner_param_;
-  pnh.param(ns + "/crosswalk/stop_margin", cp.stop_margin, 1.0);
-  pnh.param(ns + "/crosswalk/slow_margin", cp.slow_margin, 2.0);
-  pnh.param(ns + "/crosswalk/slow_velocity", cp.slow_velocity, 5.0 / 3.6);
-  pnh.param(
-    ns + "/crosswalk/stop_dynamic_object_prediction_time_margin",
-    cp.stop_dynamic_object_prediction_time_margin, 3.0);
+  cp.stop_margin = node.declare_parameter(ns + "/crosswalk/stop_margin", 1.0);
+  cp.slow_margin = node.declare_parameter(ns + "/crosswalk/slow_margin", 2.0);
+  cp.slow_velocity = node.declare_parameter(ns + "/crosswalk/slow_velocity", 5.0 / 3.6);
+  cp.stop_dynamic_object_prediction_time_margin =
+    node.declare_parameter(ns + "/crosswalk/stop_dynamic_object_prediction_time_margin", 3.0);
 
   // for walkway parameters
-  auto & wp = walkway_planner_param_;
-  pnh.param(ns + "/walkway/stop_margin", wp.stop_margin, 1.0);
+  walkway_planner_param_.stop_margin = node.declare_parameter(ns + "/walkway/stop_margin", 1.0);
 }
 
-void CrosswalkModuleManager::launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path)
+void CrosswalkModuleManager::launchNewModules(
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   for (const auto & crosswalk :
        getCrosswalksOnPath(path, planner_data_->lanelet_map, planner_data_->overall_graphs)) {
     const auto module_id = crosswalk.id();
     if (!isModuleRegistered(module_id)) {
-      registerModule(
-        std::make_shared<CrosswalkModule>(module_id, crosswalk, crosswalk_planner_param_));
+      registerModule(std::make_shared<CrosswalkModule>(
+        module_id, crosswalk, crosswalk_planner_param_, logger_, clock_));
       if (
         crosswalk.attributeOr(lanelet::AttributeNamesString::Subtype, std::string("")) ==
         lanelet::AttributeValueString::Walkway) {
-        registerModule(
-          std::make_shared<WalkwayModule>(module_id, crosswalk, walkway_planner_param_));
+        registerModule(std::make_shared<WalkwayModule>(
+          module_id, crosswalk, walkway_planner_param_, logger_, clock_));
       }
     }
   }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_crosswalk.cpp
@@ -25,8 +25,9 @@ using Line = bg::model::linestring<Point>;
 
 CrosswalkModule::CrosswalkModule(
   const int64_t module_id, const lanelet::ConstLanelet & crosswalk,
-  const PlannerParam & planner_param)
-: SceneModuleInterface(module_id),
+  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock),
   module_id_(module_id),
   crosswalk_(crosswalk),
   state_(State::APPROACH)
@@ -35,10 +36,11 @@ CrosswalkModule::CrosswalkModule(
 }
 
 bool CrosswalkModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   debug_data_ = {};
-  debug_data_.base_link2front = planner_data_->base_link2front;
+  debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m_;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
   *stop_reason =
     planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::CROSSWALK);
@@ -94,14 +96,14 @@ bool CrosswalkModule::checkStopArea(
   const boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double>, false> &
     crosswalk_polygon,
   const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & objects_ptr,
-  const pcl::PointCloud<pcl::PointXYZ>::ConstSharedPtr & no_ground_pointcloud_ptr,
+  const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & no_ground_pointcloud_ptr,
   autoware_planning_msgs::msg::PathWithLaneId & output, bool * insert_stop)
 {
   output = input;
   *insert_stop = false;
   bool pedestrian_found = false;
   bool object_found = false;
-  rclcpp::Time current_time = this->now();
+  rclcpp::Time current_time = clock_->now();
 
   // create stop area
   std::vector<Point> path_collision_points;
@@ -124,7 +126,7 @@ bool CrosswalkModule::checkStopArea(
   Polygon stop_polygon;
   {
     constexpr double extension_margin = 1.0;
-    const double width = planner_data_->vehicle_width;
+    const double width = planner_data_->vehicle_info_.vehicle_width_m_;
     const double d = (width / 2.0) + extension_margin;
     const auto cp0 = path_collision_points.at(0);
     const auto cp1 = path_collision_points.at(1);
@@ -172,7 +174,7 @@ bool CrosswalkModule::checkStopArea(
       for (const auto & object_path : object.state.predicted_paths) {
         for (size_t k = 0; k < object_path.path.size() - 1; ++k) {
           if (
-            (current_time - object_path.path.at(k).header.stamp).toSec() <
+            (current_time - object_path.path.at(k).header.stamp).seconds() <
             planner_param_.stop_dynamic_object_prediction_time_margin) {
             const auto op0 = object_path.path.at(k).pose.pose.position;
             const auto op1 = object_path.path.at(k + 1).pose.pose.position;
@@ -206,7 +208,7 @@ bool CrosswalkModule::checkStopArea(
 bool CrosswalkModule::checkSlowArea(
   const autoware_planning_msgs::msg::PathWithLaneId & input, const Polygon & polygon,
   const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr & objects_ptr,
-  const pcl::PointCloud<pcl::PointXYZ>::ConstSharedPtr & no_ground_pointcloud_ptr,
+  const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & no_ground_pointcloud_ptr,
   autoware_planning_msgs::msg::PathWithLaneId & output)
 {
   output = input;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/scene_walkway.cpp
@@ -25,19 +25,25 @@ using Line = bg::model::linestring<Point>;
 
 WalkwayModule::WalkwayModule(
   const int64_t module_id, const lanelet::ConstLanelet & walkway,
-  const PlannerParam & planner_param)
-: SceneModuleInterface(module_id), module_id_(module_id), walkway_(walkway), state_(State::APPROACH)
+  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock),
+  module_id_(module_id),
+  walkway_(walkway),
+  state_(State::APPROACH)
 {
   planner_param_ = planner_param;
 }
 
 bool WalkwayModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   debug_data_ = {};
-  debug_data_.base_link2front = planner_data_->base_link2front;
+  debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m_;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
-  *stop_reason = planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::WALKWAY);
+  *stop_reason =
+    planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::WALKWAY);
 
   const auto input = *path;
 
@@ -60,7 +66,7 @@ bool WalkwayModule::modifyPathVelocity(
       planner_data_->current_pose.pose.position.x, planner_data_->current_pose.pose.position.y};
     const double distance = bg::distance(polygon, self_pose);
     const double distance_threshold =
-      planner_param_.stop_margin + planner_data_->base_link2front + 1.0;
+      planner_param_.stop_margin + planner_data_->vehicle_info_.max_longitudinal_offset_m_ + 1.0;
     if (distance < distance_threshold && planner_data_->isVehicleStopping()) state_ = State::STOP;
     return true;
   } else if (state_ == State::STOP) {

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/crosswalk/util.cpp
@@ -88,7 +88,7 @@ bool insertTargetVelocityPoint(
 
     // search target point index
     size_t insert_target_point_idx = 0;
-    const double base_link2front = planner_data.base_link2front;
+    const double base_link2front = planner_data.vehicle_info_.max_longitudinal_offset_m_;
     double length_sum = 0;
 
     const double target_length = margin + base_link2front;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/debug.cpp
@@ -28,7 +28,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   const DebugData & debug_data, const int64_t module_id)
 {
   visualization_msgs::msg::MarkerArray msg;
-  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -37,7 +36,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -61,7 +59,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.dead_line_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "dead_line_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -85,7 +82,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -116,7 +112,7 @@ visualization_msgs::msg::MarkerArray DetectionAreaModule::createDebugMarkerArray
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
-  appendMarkerArray(createMarkerArray(debug_data_, module_id_), &debug_marker_array);
-
+  appendMarkerArray(
+    createMarkerArray(debug_data_, module_id_), this->clock_->now(), &debug_marker_array);
   return debug_marker_array;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
@@ -20,7 +20,8 @@
 namespace
 {
 std::unordered_map<int64_t, lanelet::DetectionAreaConstPtr> getDetectionAreaRegElemsOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::unordered_map<int64_t, lanelet::DetectionAreaConstPtr> detection_area_reg_elems;
 
@@ -37,7 +38,8 @@ std::unordered_map<int64_t, lanelet::DetectionAreaConstPtr> getDetectionAreaRegE
 }
 
 std::set<int64_t> getLaneletIdSetOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::set<int64_t> lanelet_id_set;
   for (const auto & regelem : getDetectionAreaRegElemsOnPath(path, lanelet_map)) {
@@ -47,13 +49,11 @@ std::set<int64_t> getLaneletIdSetOnPath(
 }
 }  // namespace
 
-DetectionAreaModuleManager::DetectionAreaModuleManager()
-: SceneModuleManagerInterface(getModuleName())
+DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
+: SceneModuleManagerInterface(node, getModuleName())
 {
-  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
-  auto & p = planner_param_;
-  pnh.param(ns + "/stop_margin", p.stop_margin, 0.0);
+  planner_param_.stop_margin = node.declare_parameter(ns + "/stop_margin", 0.0);
 }
 
 void DetectionAreaModuleManager::launchNewModules(
@@ -65,7 +65,7 @@ void DetectionAreaModuleManager::launchNewModules(
     const auto module_id = detection_area_reg_elem.first;
     if (!isModuleRegistered(module_id)) {
       registerModule(std::make_shared<DetectionAreaModule>(
-        module_id, *(detection_area_reg_elem.second), planner_param_));
+        module_id, *(detection_area_reg_elem.second), planner_param_, logger_, clock_));
     }
   }
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
@@ -76,8 +76,8 @@ double calcArcLengthFromWayPoint(
 }
 
 double calcSignedArcLength(
-  const autoware_planning_msgs::msg::PathWithLaneId & input_path, const geometry_msgs::msg::Pose & p1,
-  const Eigen::Vector2d & p2)
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path,
+  const geometry_msgs::msg::Pose & p1, const Eigen::Vector2d & p2)
 {
   std::pair<int, double> src =
     findWayPointAndDistance(input_path, Eigen::Vector2d(p1.position.x, p1.position.y));
@@ -111,8 +111,9 @@ namespace bg = boost::geometry;
 
 DetectionAreaModule::DetectionAreaModule(
   const int64_t module_id, const lanelet::autoware::DetectionArea & detection_area_reg_elem,
-  const PlannerParam & planner_param)
-: SceneModuleInterface(module_id),
+  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock),
   module_id_(module_id),
   detection_area_reg_elem_(detection_area_reg_elem),
   state_(State::APPROACH)
@@ -121,12 +122,13 @@ DetectionAreaModule::DetectionAreaModule(
 }
 
 bool DetectionAreaModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   const auto input_path = *path;
 
-  debug_data_ = {};
-  debug_data_.base_link2front = planner_data_->base_link2front;
+  debug_data_ = DebugData{};
+  debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m_;
   *stop_reason =
     planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::DETECTION_AREA);
 
@@ -191,7 +193,7 @@ bool DetectionAreaModule::modifyPathVelocity(
       if (
         state_ != State::STOP &&
         calcSignedDistance(self_pose.pose, stop_line_point) < pass_judge_line_distance) {
-        ROS_WARN_THROTTLE(1.0, "[detection_area] vehicle is over stop border");
+        RCLCPP_WARN_THROTTLE(logger_, *clock_, 1.0, "[detection_area] vehicle is over stop border");
         state_ = State::PASS;
         return true;
       }
@@ -215,7 +217,8 @@ bool DetectionAreaModule::modifyPathVelocity(
 }
 
 bool DetectionAreaModule::isOverDeadLine(
-  const geometry_msgs::msg::Pose & self_pose, const autoware_planning_msgs::msg::PathWithLaneId & input_path,
+  const geometry_msgs::msg::Pose & self_pose,
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path,
   const size_t & dead_line_point_idx, const Eigen::Vector2d & dead_line_point,
   const double dead_line_range)
 {
@@ -251,7 +254,7 @@ bool DetectionAreaModule::isOverDeadLine(
   }
 
   if (0 < tf_dead_line_pose2self_pose.getOrigin().x()) {
-    ROS_WARN("[traffic_light] vehicle is over dead line");
+    RCLCPP_WARN(logger_, "[traffic_light] vehicle is over dead line");
     return true;
   }
 
@@ -259,7 +262,7 @@ bool DetectionAreaModule::isOverDeadLine(
 }
 
 bool DetectionAreaModule::isPointsWithinDetectionArea(
-  const pcl::PointCloud<pcl::PointXYZ>::ConstSharedPtr & no_ground_pointcloud_ptr,
+  const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & no_ground_pointcloud_ptr,
   const lanelet::ConstPolygons3d & detection_areas)
 {
   for (const auto & da : detection_areas) {
@@ -287,7 +290,8 @@ bool DetectionAreaModule::insertTargetVelocityPoint(
   const autoware_planning_msgs::msg::PathWithLaneId & input,
   const boost::geometry::model::linestring<boost::geometry::model::d2::point_xy<double>> &
     stop_line,
-  const double & margin, const double & velocity, autoware_planning_msgs::msg::PathWithLaneId & output)
+  const double & margin, const double & velocity,
+  autoware_planning_msgs::msg::PathWithLaneId & output)
 {
   // create target point
   Eigen::Vector2d target_point;
@@ -350,7 +354,7 @@ bool DetectionAreaModule::createTargetPoint(
 
     // search target point index
     target_point_idx = 0;
-    const double base_link2front = planner_data_->base_link2front;
+    const double base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m_;
     double length_sum = 0;
 
     const double target_length = margin + base_link2front;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -23,45 +23,10 @@ namespace
 {
 using State = IntersectionModule::State;
 
-visualization_msgs::msg::MarkerArray createLaneletsAreaMarkerArray(
-  const std::vector<lanelet::ConstLanelet> & lanelets, const std::string & ns,
-  const int64_t lane_id)
-{
-  const auto current_time = this->now();
-  visualization_msgs::msg::MarkerArray msg;
-
-  for (const auto & lanelet : lanelets) {
-    visualization_msgs::msg::Marker marker{};
-    marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
-
-    marker.ns = ns;
-    marker.id = lanelet.id();
-    marker.lifetime = rclcpp::Duration(0.3);
-    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
-    marker.action = visualization_msgs::msg::Marker::ADD;
-    marker.pose.orientation = createMarkerOrientation(0, 0, 0, 1.0);
-    marker.scale = createMarkerScale(0.1, 0.0, 0.0);
-    marker.color = createMarkerColor(0.0, 1.0, 0.0, 0.999);
-    for (const auto & p : lanelet.polygon3d()) {
-      geometry_msgs::msg::Point point;
-      point.x = p.x();
-      point.y = p.y();
-      point.z = p.z();
-      marker.points.push_back(point);
-    }
-    if (!marker.points.empty()) marker.points.push_back(marker.points.front());
-    msg.markers.push_back(marker);
-  }
-
-  return msg;
-}
-
 visualization_msgs::msg::MarkerArray createLaneletPolygonsMarkerArray(
   const std::vector<lanelet::CompoundPolygon3d> & polygons, const std::string & ns,
   const int64_t lane_id)
 {
-  const auto current_time = this->now();
   visualization_msgs::msg::MarkerArray msg;
 
   int32_t i = 0;
@@ -69,7 +34,6 @@ visualization_msgs::msg::MarkerArray createLaneletPolygonsMarkerArray(
   for (const auto & polygon : polygons) {
     visualization_msgs::msg::Marker marker{};
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
 
     marker.ns = ns;
     marker.id = uid + i++;
@@ -97,12 +61,10 @@ visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
   const geometry_msgs::msg::Polygon & polygon, const std::string & ns, const int64_t lane_id,
   const double r, const double g, const double b)
 {
-  const auto current_time = this->now();
   visualization_msgs::msg::MarkerArray msg;
 
   visualization_msgs::msg::Marker marker{};
   marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
 
   marker.ns = ns;
   marker.id = lane_id;
@@ -129,12 +91,10 @@ visualization_msgs::msg::MarkerArray createObjectsMarkerArray(
   const autoware_perception_msgs::msg::DynamicObjectArray & objects, const std::string & ns,
   const int64_t lane_id, const double r, const double g, const double b)
 {
-  const auto current_time = this->now();
   visualization_msgs::msg::MarkerArray msg;
 
   visualization_msgs::msg::Marker marker{};
   marker.header.frame_id = "map";
-  marker.header.stamp = current_time;
   marker.ns = ns;
 
   int32_t uid = planning_utils::bitShift(lane_id);
@@ -157,14 +117,12 @@ visualization_msgs::msg::MarkerArray createPathMarkerArray(
   const autoware_planning_msgs::msg::PathWithLaneId & path, const std::string & ns,
   const int64_t lane_id, const double r, const double g, const double b)
 {
-  const auto current_time = this->now();
   visualization_msgs::msg::MarkerArray msg;
   int32_t uid = planning_utils::bitShift(lane_id);
   int32_t i = 0;
   for (const auto & p : path.points) {
     visualization_msgs::msg::Marker marker{};
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = ns;
     marker.id = uid + i++;
     marker.lifetime = rclcpp::Duration(0.3);
@@ -191,7 +149,6 @@ visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
 
   visualization_msgs::msg::Marker marker_virtual_wall{};
   marker_virtual_wall.header.frame_id = "map";
-  marker_virtual_wall.header.stamp = this->now();
   marker_virtual_wall.ns = "stop_virtual_wall";
   marker_virtual_wall.id = lane_id;
   marker_virtual_wall.lifetime = rclcpp::Duration(0.5);
@@ -205,7 +162,6 @@ visualization_msgs::msg::MarkerArray createVirtualWallMarkerArray(
 
   visualization_msgs::msg::Marker marker_factor_text{};
   marker_factor_text.header.frame_id = "map";
-  marker_factor_text.header.stamp = this->now();
   marker_factor_text.ns = "factor_text";
   marker_factor_text.id = lane_id;
   marker_factor_text.lifetime = rclcpp::Duration(0.5);
@@ -225,12 +181,10 @@ visualization_msgs::msg::MarkerArray createPoseMarkerArray(
   const geometry_msgs::msg::Pose & pose, const std::string & ns, const int64_t id, const double r,
   const double g, const double b)
 {
-  const auto current_time = this->now();
   visualization_msgs::msg::MarkerArray msg;
 
   visualization_msgs::msg::Marker marker_line{};
   marker_line.header.frame_id = "map";
-  marker_line.header.stamp = current_time;
   marker_line.ns = ns + "_line";
   marker_line.id = id;
   marker_line.lifetime = rclcpp::Duration(0.3);
@@ -267,47 +221,48 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
   const auto state = state_machine_.getState();
+  const auto current_time = this->clock_->now();
 
   appendMarkerArray(
-    createPathMarkerArray(debug_data_.path_raw, "path_raw", lane_id_, 0.0, 1.0, 1.0),
+    createPathMarkerArray(debug_data_.path_raw, "path_raw", lane_id_, 0.0, 1.0, 1.0), current_time,
     &debug_marker_array);
 
   appendMarkerArray(
     createLaneletPolygonsMarkerArray(debug_data_.detection_area, "detection_area", lane_id_),
-    &debug_marker_array);
+    current_time, &debug_marker_array);
 
   appendMarkerArray(
     createPolygonMarkerArray(debug_data_.ego_lane_polygon, "ego_lane", lane_id_, 0.0, 0.3, 0.7),
-    &debug_marker_array);
+    current_time, &debug_marker_array);
 
   appendMarkerArray(
     createPolygonMarkerArray(
       debug_data_.stuck_vehicle_detect_area, "stuck_vehicle_detect_area", lane_id_, 0.0, 0.5, 0.5),
-    &debug_marker_array);
+    current_time, &debug_marker_array);
 
   appendMarkerArray(
     createObjectsMarkerArray(
       debug_data_.conflicting_targets, "conflicting_targets", lane_id_, 0.99, 0.4, 0.0),
-    &debug_marker_array);
+    current_time, &debug_marker_array);
 
   appendMarkerArray(
     createObjectsMarkerArray(debug_data_.stuck_targets, "stuck_targets", lane_id_, 0.99, 0.99, 0.2),
-    &debug_marker_array);
+    current_time, &debug_marker_array);
 
   if (state == IntersectionModule::State::STOP) {
     appendMarkerArray(
       createPoseMarkerArray(
         debug_data_.stop_point_pose, "stop_point_pose", lane_id_, 1.0, 0.0, 0.0),
-      &debug_marker_array);
+      current_time, &debug_marker_array);
 
     appendMarkerArray(
       createPoseMarkerArray(
         debug_data_.judge_point_pose, "judge_point_pose", lane_id_, 1.0, 1.0, 0.5),
-      &debug_marker_array);
+      current_time, &debug_marker_array);
 
     appendMarkerArray(
       createVirtualWallMarkerArray(debug_data_.virtual_wall_pose, lane_id_, "intersection"),
-      &debug_marker_array);
+      current_time, &debug_marker_array);
   }
 
   return debug_marker_array;
@@ -319,16 +274,17 @@ visualization_msgs::msg::MarkerArray MergeFromPrivateRoadModule::createDebugMark
 
   const auto state = state_machine_.getState();
 
+  const auto current_time = this->clock_->now();
   if (state == MergeFromPrivateRoadModule::State::STOP) {
     appendMarkerArray(
       createPoseMarkerArray(
         debug_data_.stop_point_pose, "stop_point_pose", lane_id_, 1.0, 0.0, 0.0),
-      &debug_marker_array);
+      current_time, &debug_marker_array);
 
     appendMarkerArray(
       createVirtualWallMarkerArray(
         debug_data_.virtual_wall_pose, lane_id_, "merge_from_private_road"),
-      &debug_marker_array);
+      current_time, &debug_marker_array);
   }
 
   return debug_marker_array;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -23,7 +23,8 @@
 namespace
 {
 std::vector<lanelet::ConstLanelet> getLaneletsOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<lanelet::ConstLanelet> lanelets;
 
@@ -53,22 +54,21 @@ std::set<int64_t> getLaneIdSetOnPath(const autoware_planning_msgs::msg::PathWith
 
 }  // namespace
 
-IntersectionModuleManager::IntersectionModuleManager()
-: SceneModuleManagerInterface(getModuleName())
+IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
+: SceneModuleManagerInterface(node, getModuleName())
 {
-  rclcpp::NodeHandle pnh("~");
   const std::string ns(getModuleName());
   auto & p = planner_param_;
-  pnh.param(ns + "/state_transit_mergin_time", p.state_transit_mergin_time, 2.0);
-  pnh.param(ns + "/decel_velocoity", p.decel_velocoity, 30.0 / 3.6);
-  pnh.param(ns + "/path_expand_width", p.path_expand_width, 2.0);
-  pnh.param(ns + "/stop_line_margin", p.stop_line_margin, 1.0);
-  pnh.param(ns + "/stuck_vehicle_detect_dist", p.stuck_vehicle_detect_dist, 5.0);
-  pnh.param(ns + "/stuck_vehicle_ignore_dist", p.stuck_vehicle_ignore_dist, 5.0) +
-    planner_data_->base_link2front;
-  pnh.param(ns + "/stuck_vehicle_vel_thr", p.stuck_vehicle_vel_thr, 3.0 / 3.6);
-  pnh.param(ns + "/intersection_velocity", p.intersection_velocity, 10.0 / 3.6);
-  pnh.param(ns + "/detection_area_length", p.detection_area_length, 200.0);
+  p.state_transit_mergin_time = node.declare_parameter(ns + "/state_transit_mergin_time", 2.0);
+  p.decel_velocoity = node.declare_parameter(ns + "/decel_velocoity", 30.0 / 3.6);
+  p.path_expand_width = node.declare_parameter(ns + "/path_expand_width", 2.0);
+  p.stop_line_margin = node.declare_parameter(ns + "/stop_line_margin", 1.0);
+  p.stuck_vehicle_detect_dist = node.declare_parameter(ns + "/stuck_vehicle_detect_dist", 5.0);
+  p.stuck_vehicle_ignore_dist = node.declare_parameter(ns + "/stuck_vehicle_ignore_dist", 5.0) +
+                                planner_data_->vehicle_info_.max_longitudinal_offset_m_;
+  p.stuck_vehicle_vel_thr = node.declare_parameter(ns + "/stuck_vehicle_vel_thr", 3.0 / 3.6);
+  p.intersection_velocity = node.declare_parameter(ns + "/intersection_velocity", 10.0 / 3.6);
+  p.detection_area_length = node.declare_parameter(ns + "/detection_area_length", 200.0);
 }
 
 void IntersectionModuleManager::launchNewModules(
@@ -99,12 +99,12 @@ void IntersectionModuleManager::launchNewModules(
       const std::string next_lane_location = next_lane.attributeOr("location", "else");
       if (lane_location == "private" && next_lane_location != "private") {
         registerModule(std::make_shared<MergeFromPrivateRoadModule>(
-          module_id, lane_id, planner_data_, planner_param_));
+          module_id, lane_id, planner_data_, planner_param_, logger_, clock_));
       }
     }
 
-    registerModule(
-      std::make_shared<IntersectionModule>(module_id, lane_id, planner_data_, planner_param_));
+    registerModule(std::make_shared<IntersectionModule>(
+      module_id, lane_id, planner_data_, planner_param_, logger_, clock_));
   }
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -30,8 +30,9 @@ namespace bg = boost::geometry;
 
 IntersectionModule::IntersectionModule(
   const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-  const PlannerParam & planner_param)
-: SceneModuleInterface(module_id), lane_id_(lane_id)
+  const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock), lane_id_(lane_id)
 {
   planner_param_ = planner_param;
   const auto & assigned_lanelet = planner_data->lanelet_map->laneletLayer.get(lane_id);
@@ -41,9 +42,10 @@ IntersectionModule::IntersectionModule(
 }
 
 bool IntersectionModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
-  ROS_DEBUG("[intersection] ===== plan start =====");
+  RCLCPP_DEBUG(logger_, "===== plan start =====");
   debug_data_ = {};
   *stop_reason =
     planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::INTERSECTION);
@@ -52,7 +54,7 @@ bool IntersectionModule::modifyPathVelocity(
   debug_data_.path_raw = input_path;
 
   State current_state = state_machine_.getState();
-  ROS_DEBUG("[Intersection] lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
+  RCLCPP_DEBUG(logger_, "lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
 
   /* get current pose */
   geometry_msgs::msg::PoseStamped current_pose = planner_data_->current_pose;
@@ -66,7 +68,7 @@ bool IntersectionModule::modifyPathVelocity(
   util::getObjectivePolygons(
     lanelet_map_ptr, routing_graph_ptr, lane_id_, planner_param_, &detection_areas);
   if (detection_areas.empty()) {
-    ROS_DEBUG("[Intersection] no detection area. skip computation.");
+    RCLCPP_DEBUG(logger_, "no detection area. skip computation.");
     return true;
   }
   debug_data_.detection_area = detection_areas;
@@ -78,27 +80,28 @@ bool IntersectionModule::modifyPathVelocity(
   if (!util::generateStopLine(
         lane_id_, detection_areas, planner_data_, planner_param_, path, &stop_line_idx,
         &pass_judge_line_idx, &first_idx_inside_lane)) {
-    ROS_WARN_DELAYED_THROTTLE(1.0, "[IntersectionModule::run] setStopLineIdx fail");
-    ROS_DEBUG("[intersection] ===== plan end =====");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(
+      logger_, *clock_, 1.0, "[IntersectionModule::run] setStopLineIdx fail");
+    RCLCPP_DEBUG(logger_, "===== plan end =====");
     return false;
   }
 
   if (stop_line_idx <= 0 || pass_judge_line_idx <= 0) {
-    ROS_DEBUG("[Intersection] stop line or pass judge line is at path[0], ignore planning.");
-    ROS_DEBUG("[intersection] ===== plan end =====");
+    RCLCPP_DEBUG(logger_, "stop line or pass judge line is at path[0], ignore planning.");
+    RCLCPP_DEBUG(logger_, "===== plan end =====");
     return true;
   }
 
   /* calc closest index */
   int closest_idx = -1;
   if (!planning_utils::calcClosestIndex(input_path, current_pose.pose, closest_idx)) {
-    ROS_WARN_DELAYED_THROTTLE(1.0, "[Intersection] calcClosestIndex fail");
-    ROS_DEBUG("[intersection] ===== plan end =====");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(logger_, *clock_, 1.0, "[Intersection] calcClosestIndex fail");
+    RCLCPP_DEBUG(logger_, "===== plan end =====");
     return false;
   }
 
-  debug_data_.virtual_wall_pose =
-    util::getAheadPose(stop_line_idx, planner_data_->base_link2front, *path);
+  debug_data_.virtual_wall_pose = util::getAheadPose(
+    stop_line_idx, planner_data_->vehicle_info_.max_longitudinal_offset_m_, *path);
   debug_data_.stop_point_pose = path->points.at(stop_line_idx).point.pose;
   debug_data_.judge_point_pose = path->points.at(pass_judge_line_idx).point.pose;
 
@@ -109,8 +112,8 @@ bool IntersectionModule::modifyPathVelocity(
     is_over_pass_judge_line = util::isAheadOf(current_pose.pose, pass_judge_line);
   }
   if (current_state == State::GO && is_over_pass_judge_line) {
-    ROS_DEBUG("[Intersection] over the pass judge line. no plan needed.");
-    ROS_DEBUG("[intersection] ===== plan end =====");
+    RCLCPP_DEBUG(logger_, "over the pass judge line. no plan needed.");
+    RCLCPP_DEBUG(logger_, "===== plan end =====");
     return true;  // no plan needed.
   }
 
@@ -121,7 +124,8 @@ bool IntersectionModule::modifyPathVelocity(
   bool has_collision = checkCollision(*path, detection_areas, objects_ptr, closest_idx);
   bool is_stuck = checkStuckVehicleInIntersection(*path, closest_idx, stop_line_idx, objects_ptr);
   bool is_entry_prohibited = (has_collision || is_stuck);
-  state_machine_.setStateWithMarginTime(is_entry_prohibited ? State::STOP : State::GO);
+  state_machine_.setStateWithMarginTime(
+    is_entry_prohibited ? State::STOP : State::GO, logger_, *clock_);
 
   /* set stop speed : TODO behavior on straight lane should be improved*/
   if (state_machine_.getState() == State::STOP) {
@@ -141,19 +145,19 @@ bool IntersectionModule::modifyPathVelocity(
     planning_utils::appendStopReason(stop_factor, stop_reason);
   }
 
-  ROS_DEBUG("[intersection] ===== plan end =====");
+  RCLCPP_DEBUG(logger_, "===== plan end =====");
   return true;
 }
 
 void IntersectionModule::cutPredictPathWithDuration(
   autoware_perception_msgs::msg::DynamicObjectArray * objects_ptr, const double time_thr) const
 {
-  const rclcpp::Time current_time = this->now();
+  const rclcpp::Time current_time = clock_->now();
   for (auto & object : objects_ptr->objects) {                    // each objects
     for (auto & predicted_path : object.state.predicted_paths) {  // each predicted paths
       std::vector<geometry_msgs::msg::PoseWithCovarianceStamped> vp;
       for (auto & predicted_pose : predicted_path.path) {  // each path points
-        if ((predicted_pose.header.stamp - current_time).toSec() < time_thr) {
+        if ((rclcpp::Time(predicted_pose.header.stamp) - current_time).seconds() < time_thr) {
           vp.push_back(predicted_pose);
         }
       }
@@ -165,7 +169,8 @@ void IntersectionModule::cutPredictPathWithDuration(
 bool IntersectionModule::checkCollision(
   const autoware_planning_msgs::msg::PathWithLaneId & path,
   const std::vector<lanelet::CompoundPolygon3d> & detection_areas,
-  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr, const int closest_idx)
+  const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr,
+  const int closest_idx)
 {
   /* generate ego-lane polygon */
   const Polygon2d ego_poly = generateEgoIntersectionLanePolygon(
@@ -229,8 +234,8 @@ bool IntersectionModule::checkCollision(
 }
 
 Polygon2d IntersectionModule::generateEgoIntersectionLanePolygon(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx, const int start_idx,
-  const double extra_dist, const double ignore_dist) const
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
+  const int start_idx, const double extra_dist, const double ignore_dist) const
 {
   const size_t assigned_lane_start_idx = start_idx;
   size_t assigned_lane_end_idx = 0;
@@ -248,7 +253,7 @@ Polygon2d IntersectionModule::generateEgoIntersectionLanePolygon(
   {
     //decide start idx with considering ignore_dist
     double dist_sum = 0.0;
-    for (int i = assigned_lane_start_idx + 1; i < assigned_lane_end_idx; ++i) {
+    for (size_t i = assigned_lane_start_idx + 1; i < assigned_lane_end_idx; ++i) {
       dist_sum += planning_utils::calcDist2d(path.points.at(i), path.points.at(i - 1));
       ++ego_area_start_idx;
       if (dist_sum > ignore_dist) break;
@@ -311,13 +316,14 @@ double IntersectionModule::calcIntersectionPassingTime(
   // TODO set to be reasonable
   const double passing_time = dist_sum / planner_param_.intersection_velocity;
 
-  ROS_DEBUG("[intersection] intersection dist = %f, passing_time = %f", dist_sum, passing_time);
+  RCLCPP_DEBUG(logger_, "intersection dist = %f, passing_time = %f", dist_sum, passing_time);
 
   return passing_time;
 }
 
 bool IntersectionModule::checkStuckVehicleInIntersection(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx, const int stop_idx,
+  const autoware_planning_msgs::msg::PathWithLaneId & path, const int closest_idx,
+  const int stop_idx,
   const autoware_perception_msgs::msg::DynamicObjectArray::ConstSharedPtr objects_ptr) const
 {
   const Polygon2d stuck_vehicle_detect_area = generateEgoIntersectionLanePolygon(
@@ -335,7 +341,7 @@ bool IntersectionModule::checkStuckVehicleInIntersection(
     }
     const auto object_pos = object.state.pose_covariance.pose.position;
     if (bg::within(to_bg2d(object_pos), stuck_vehicle_detect_area)) {
-      ROS_DEBUG("[intersection] stuck vehicle found.");
+      RCLCPP_DEBUG(logger_, "stuck vehicle found.");
       debug_data_.stuck_targets.objects.push_back(object);
       return true;
     }
@@ -357,7 +363,8 @@ bool IntersectionModule::isTargetVehicleType(
   return false;
 }
 
-void IntersectionModule::StateMachine::setStateWithMarginTime(State state)
+void IntersectionModule::StateMachine::setStateWithMarginTime(
+  State state, rclcpp::Logger logger, rclcpp::Clock & clock)
 {
   /* same state request */
   if (state_ == state) {
@@ -375,9 +382,9 @@ void IntersectionModule::StateMachine::setStateWithMarginTime(State state)
   /* STOP -> GO */
   if (state == State::GO) {
     if (start_time_ == nullptr) {
-      start_time_ = std::make_shared<rclcpp::Time>(this->now());
+      start_time_ = std::make_shared<rclcpp::Time>(clock.now());
     } else {
-      const double duration = (this->now() - *start_time_).toSec();
+      const double duration = (clock.now() - *start_time_).seconds();
       if (duration > margin_time_) {
         state_ = State::GO;
         start_time_ = nullptr;  // reset timer
@@ -386,7 +393,7 @@ void IntersectionModule::StateMachine::setStateWithMarginTime(State state)
     return;
   }
 
-  ROS_ERROR("[StateMachine] : Unsuitable state. ignore request.");
+  RCLCPP_ERROR(logger, "[StateMachine] : Unsuitable state. ignore request.");
   return;
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -30,8 +30,9 @@ namespace bg = boost::geometry;
 
 MergeFromPrivateRoadModule::MergeFromPrivateRoadModule(
   const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
-  const IntersectionModule::PlannerParam & planner_param)
-: SceneModuleInterface(module_id), lane_id_(lane_id)
+  const IntersectionModule::PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock), lane_id_(lane_id)
 {
   planner_param_ = planner_param;
   const auto & assigned_lanelet = planner_data->lanelet_map->laneletLayer.get(lane_id);
@@ -39,7 +40,8 @@ MergeFromPrivateRoadModule::MergeFromPrivateRoadModule(
 }
 
 bool MergeFromPrivateRoadModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   debug_data_ = {};
   *stop_reason = planning_utils::initializeStopReason(
@@ -49,8 +51,9 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   debug_data_.path_raw = input_path;
 
   State current_state = state_machine_.getState();
-  ROS_DEBUG(
-    "[MergeFromPrivateRoad] lane_id = %ld, state = %s", lane_id_, toString(current_state).c_str());
+  RCLCPP_DEBUG(
+    logger_, "[MergeFromPrivateRoad] lane_id = %ld, state = %s", lane_id_,
+    toString(current_state).c_str());
 
   /* get current pose */
   geometry_msgs::msg::PoseStamped current_pose = planner_data_->current_pose;
@@ -64,7 +67,7 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   util::getObjectivePolygons(
     lanelet_map_ptr, routing_graph_ptr, lane_id_, planner_param_, &detection_areas);
   if (detection_areas.empty()) {
-    ROS_DEBUG("[MergeFromPrivateRoad] no detection area. skip computation.");
+    RCLCPP_DEBUG(logger_, "[MergeFromPrivateRoad] no detection area. skip computation.");
     return true;
   }
   debug_data_.detection_area = detection_areas;
@@ -76,17 +79,19 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   if (!util::generateStopLine(
         lane_id_, detection_areas, planner_data_, planner_param_, path, &stop_line_idx,
         &judge_line_idx, &first_idx_inside_lane)) {
-    ROS_WARN_DELAYED_THROTTLE(1.0, "[MergeFromPrivateRoadModule::run] setStopLineIdx fail");
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(
+      logger_, *clock_, 1.0, "[MergeFromPrivateRoadModule::run] setStopLineIdx fail");
     return false;
   }
 
   if (stop_line_idx <= 0 || judge_line_idx <= 0) {
-    ROS_DEBUG("[MergeFromPrivateRoad] stop line or judge line is at path[0], ignore planning.");
+    RCLCPP_DEBUG(
+      logger_, "[MergeFromPrivateRoad] stop line or judge line is at path[0], ignore planning.");
     return true;
   }
 
-  debug_data_.virtual_wall_pose =
-    util::getAheadPose(stop_line_idx, planner_data_->base_link2front, *path);
+  debug_data_.virtual_wall_pose = util::getAheadPose(
+    stop_line_idx, planner_data_->vehicle_info_.max_longitudinal_offset_m_, *path);
   debug_data_.stop_point_pose = path->points.at(stop_line_idx).point.pose;
   if (first_idx_inside_lane != -1) {
     debug_data_.first_collision_point = path->points.at(first_idx_inside_lane).point.pose.position;
@@ -119,7 +124,8 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(
   return true;
 }
 
-void MergeFromPrivateRoadModule::StateMachine::setStateWithMarginTime(State state)
+void MergeFromPrivateRoadModule::StateMachine::setStateWithMarginTime(
+  State state, rclcpp::Logger logger, rclcpp::Clock & clock)
 {
   /* same state request */
   if (state_ == state) {
@@ -137,9 +143,9 @@ void MergeFromPrivateRoadModule::StateMachine::setStateWithMarginTime(State stat
   /* STOP -> GO */
   if (state == State::GO) {
     if (start_time_ == nullptr) {
-      start_time_ = std::make_shared<rclcpp::Time>(this->now());
+      start_time_ = std::make_shared<rclcpp::Time>(clock.now());
     } else {
-      const double duration = (this->now() - *start_time_).toSec();
+      const double duration = (clock.now() - *start_time_).seconds();
       if (duration > margin_time_) {
         state_ = State::GO;
         start_time_ = nullptr;  // reset timer
@@ -148,7 +154,7 @@ void MergeFromPrivateRoadModule::StateMachine::setStateWithMarginTime(State stat
     return;
   }
 
-  ROS_ERROR("[StateMachine] : Unsuitable state. ignore request.");
+  RCLCPP_ERROR(logger, "[StateMachine] : Unsuitable state. ignore request.");
   return;
 }
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <lanelet2_core/geometry/Polygon.h>
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
@@ -30,7 +30,8 @@ namespace bg = boost::geometry;
 namespace util
 {
 int insertPoint(
-  const geometry_msgs::msg::Pose & in_pose, autoware_planning_msgs::msg::PathWithLaneId * inout_path)
+  const geometry_msgs::msg::Pose & in_pose,
+  autoware_planning_msgs::msg::PathWithLaneId * inout_path)
 {
   static constexpr double dist_thr = 10.0;
   static constexpr double angle_thr = M_PI / 1.5;
@@ -54,7 +55,7 @@ int insertPoint(
 
 bool splineInterpolate(
   const autoware_planning_msgs::msg::PathWithLaneId & input, const double interval,
-  autoware_planning_msgs::msg::PathWithLaneId * output)
+  autoware_planning_msgs::msg::PathWithLaneId * output, rclcpp::Logger logger)
 {
   *output = input;
 
@@ -105,7 +106,7 @@ bool splineInterpolate(
       base_s, base_y, resampled_s, resampled_y, spline_interpolation::Method::PCG) ||
     !spline.interpolate(
       base_s, base_z, resampled_s, resampled_z, spline_interpolation::Method::PCG)) {
-    ROS_ERROR("[IntersectionModule::splineInterpolate] spline interpolation failed.");
+    RCLCPP_ERROR(logger, "[IntersectionModule::splineInterpolate] spline interpolation failed.");
     return false;
   }
 
@@ -144,7 +145,7 @@ geometry_msgs::msg::Pose getAheadPose(
 
   double curr_dist = 0.0;
   double prev_dist = 0.0;
-  for (size_t i = start_idx; i < path.points.size() - 1 && i >= 0; ++i) {
+  for (size_t i = start_idx; i < path.points.size() - 1; ++i) {
     const geometry_msgs::msg::Pose p0 = path.points.at(i).point.pose;
     const geometry_msgs::msg::Pose p1 = path.points.at(i + 1).point.pose;
     curr_dist += planning_utils::calcDist2d(p0, p1);
@@ -217,8 +218,8 @@ bool generateStopLine(
   const int lane_id, const std::vector<lanelet::CompoundPolygon3d> detection_areas,
   const std::shared_ptr<const PlannerData> & planner_data,
   const IntersectionModule::PlannerParam & planner_param,
-  autoware_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx, int * pass_judge_line_idx,
-  int * first_idx_inside_lane)
+  autoware_planning_msgs::msg::PathWithLaneId * path, int * stop_line_idx,
+  int * pass_judge_line_idx, int * first_idx_inside_lane, const rclcpp::Logger logger)
 {
   /* set judge line dist */
   const double current_vel = planner_data->current_velocity->twist.linear.x;
@@ -231,7 +232,8 @@ bool generateStopLine(
   constexpr double interval = 0.2;
 
   const int margin_idx_dist = std::ceil(planner_param.stop_line_margin / interval);
-  const int base2front_idx_dist = std::ceil(planner_data->base_link2front / interval);
+  const int base2front_idx_dist =
+    std::ceil(planner_data->vehicle_info_.max_longitudinal_offset_m_ / interval);
   const int pass_judge_idx_dist = std::ceil(pass_judge_line_dist / interval);
 
   /* spline interpolation */
@@ -251,14 +253,15 @@ bool generateStopLine(
     // get idx of first_inside_lane point
     first_idx_ip_inside_lane = getFirstPointInsidePolygons(path_ip, detection_areas);
     if (first_idx_ip_inside_lane == -1) {
-      ROS_DEBUG("[Intersection Util] generate stopline, but no intersect line found.");
+      RCLCPP_DEBUG(logger, "[Intersection Util] generate stopline, but no intersect line found.");
       return false;
     }
     // only for visualization
     const auto first_inside_point = path_ip.points.at(first_idx_ip_inside_lane).point.pose;
     planning_utils::calcClosestIndex(*path, first_inside_point, *first_idx_inside_lane, 10.0);
     if (*first_idx_inside_lane == 0) {
-      ROS_DEBUG(
+      RCLCPP_DEBUG(
+        logger,
         "[Intersection Util] path[0] is already in the detection area. This happens if you have "
         "already "
         "crossed the stop line or are very far from the intersection. Ignore computation.");
@@ -292,7 +295,8 @@ bool generateStopLine(
     ++(*stop_line_idx);  // stop index is incremented by judge line insertion
   }
 
-  ROS_DEBUG(
+  RCLCPP_DEBUG(
+    logger,
     "[Intersection Util] generateStopLine() : stop_idx = %d, pass_judge_idx = %d, stop_idx_ip = "
     "%d, "
     "pass_judge_idx_ip = %d, has_prior_stopline = %d",
@@ -330,7 +334,7 @@ bool getStopPoseFromMap(
 bool getObjectivePolygons(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
   const int lane_id, const IntersectionModule::PlannerParam & planner_param,
-  std::vector<lanelet::CompoundPolygon3d> * polygons)
+  std::vector<lanelet::CompoundPolygon3d> * polygons, const rclcpp::Logger logger)
 {
   const auto & assigned_lanelet = lanelet_map_ptr->laneletLayer.get(lane_id);
 
@@ -411,11 +415,11 @@ bool getObjectivePolygons(
   for (const auto l : objective_lanelets_sequences) {
     for (const auto ll : l) ss_os << ll.id() << ", ";
   }
-  ROS_DEBUG(
-    "[Intersection Util] getObjectivePolygons() conflict = %s yield = %s ego = %s",
+  RCLCPP_DEBUG(
+    logger, "[Intersection Util] getObjectivePolygons() conflict = %s yield = %s ego = %s",
     ss_c.str().c_str(), ss_y.str().c_str(), ss_e.str().c_str());
-  ROS_DEBUG(
-    "[Intersection Util] getObjectivePolygons() object = %s object_sequences = %s",
+  RCLCPP_DEBUG(
+    logger, "[Intersection Util] getObjectivePolygons() object = %s object_sequences = %s",
     ss_o.str().c_str(), ss_os.str().c_str());
   return true;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/debug.cpp
@@ -24,11 +24,11 @@ namespace
 {
 using DebugData = StopLineModule::DebugData;
 
-visualization_msgs::msg::MarkerArray createMarkers(const DebugData & debug_data, const int64_t module_id)
+visualization_msgs::msg::MarkerArray createMarkers(
+  const DebugData & debug_data, const int64_t module_id)
 {
   int32_t uid = planning_utils::bitShift(module_id);
   visualization_msgs::msg::MarkerArray msg;
-  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -36,7 +36,6 @@ visualization_msgs::msg::MarkerArray createMarkers(const DebugData & debug_data,
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -60,7 +59,6 @@ visualization_msgs::msg::MarkerArray createMarkers(const DebugData & debug_data,
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -91,7 +89,8 @@ visualization_msgs::msg::MarkerArray StopLineModule::createDebugMarkerArray()
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
-  appendMarkerArray(createMarkers(debug_data_, module_id_), &debug_marker_array);
+  appendMarkerArray(
+    createMarkers(debug_data_, module_id_), this->clock_->now(), &debug_marker_array);
 
   return debug_marker_array;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
@@ -18,7 +18,8 @@
 namespace
 {
 std::vector<lanelet::TrafficSignConstPtr> getTrafficSignRegElemsOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<lanelet::TrafficSignConstPtr> traffic_sign_reg_elems;
 
@@ -36,7 +37,8 @@ std::vector<lanelet::TrafficSignConstPtr> getTrafficSignRegElemsOnPath(
 }
 
 std::vector<lanelet::ConstLineString3d> getStopLinesOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<lanelet::ConstLineString3d> stop_lines;
 
@@ -55,7 +57,8 @@ std::vector<lanelet::ConstLineString3d> getStopLinesOnPath(
 }
 
 std::set<int64_t> getStopLineIdSetOnPath(
-  const autoware_planning_msgs::msg::PathWithLaneId & path, const lanelet::LaneletMapPtr lanelet_map)
+  const autoware_planning_msgs::msg::PathWithLaneId & path,
+  const lanelet::LaneletMapPtr lanelet_map)
 {
   std::set<int64_t> stop_line_id_set;
 
@@ -68,26 +71,30 @@ std::set<int64_t> getStopLineIdSetOnPath(
 
 }  // namespace
 
-StopLineModuleManager::StopLineModuleManager() : SceneModuleManagerInterface(getModuleName()) {
-  rclcpp::NodeHandle pnh("~");
+StopLineModuleManager::StopLineModuleManager(rclcpp::Node & node)
+: SceneModuleManagerInterface(node, getModuleName())
+{
   const std::string ns(getModuleName());
   auto & p = planner_param_;
-  pnh.param(ns + "/stop_margin", p.stop_margin, 0.0);
-  pnh.param(ns + "/stop_check_dist", p.stop_check_dist, 2.0);
+  p.stop_margin = node.declare_parameter(ns + "/stop_margin", 0.0);
+  p.stop_check_dist = node.declare_parameter(ns + "/stop_check_dist", 2.0);
 }
 
-void StopLineModuleManager::launchNewModules(const autoware_planning_msgs::msg::PathWithLaneId & path)
+void StopLineModuleManager::launchNewModules(
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   for (const auto & stop_line : getStopLinesOnPath(path, planner_data_->lanelet_map)) {
     const auto module_id = stop_line.id();
     if (!isModuleRegistered(module_id)) {
-      registerModule(std::make_shared<StopLineModule>(module_id, stop_line, planner_param_));
+      registerModule(
+        std::make_shared<StopLineModule>(module_id, stop_line, planner_param_, logger_, clock_));
     }
   }
 }
 
 std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
-StopLineModuleManager::getModuleExpiredFunction(const autoware_planning_msgs::msg::PathWithLaneId & path)
+StopLineModuleManager::getModuleExpiredFunction(
+  const autoware_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto stop_line_id_set = getStopLineIdSetOnPath(path, planner_data_->lanelet_map);
 

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/debug.cpp
@@ -29,7 +29,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
 {
   int32_t uid = planning_utils::bitShift(lane_id);
   visualization_msgs::msg::MarkerArray msg;
-  rclcpp::Time current_time = this->now();
   tf2::Transform tf_base_link2front(
     tf2::Quaternion(0.0, 0.0, 0.0, 1.0), tf2::Vector3(debug_data.base_link2front, 0.0, 0.0));
 
@@ -37,7 +36,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "stop_virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -61,7 +59,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.stop_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -86,7 +83,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.dead_line_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "dead line virtual_wall";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -110,7 +106,6 @@ visualization_msgs::msg::MarkerArray createMarkerArray(
   for (size_t j = 0; j < debug_data.dead_line_poses.size(); ++j) {
     visualization_msgs::msg::Marker marker;
     marker.header.frame_id = "map";
-    marker.header.stamp = current_time;
     marker.ns = "dead line factor_text";
     marker.id = uid + j;
     marker.lifetime = rclcpp::Duration(0.5);
@@ -141,7 +136,8 @@ visualization_msgs::msg::MarkerArray TrafficLightModule::createDebugMarkerArray(
 {
   visualization_msgs::msg::MarkerArray debug_marker_array;
 
-  appendMarkerArray(createMarkerArray(debug_data_, lane_id_), &debug_marker_array);
+  appendMarkerArray(
+    createMarkerArray(debug_data_, lane_id_), this->clock_->now(), &debug_marker_array);
 
   return debug_marker_array;
 }

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -79,8 +79,8 @@ double calcArcLengthFromWayPoint(
 }
 
 double calcSignedArcLength(
-  const autoware_planning_msgs::msg::PathWithLaneId & input_path, const geometry_msgs::msg::Pose & p1,
-  const Eigen::Vector2d & p2)
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path,
+  const geometry_msgs::msg::Pose & p1, const Eigen::Vector2d & p2)
 {
   std::pair<int, double> src =
     findWayPointAndDistance(input_path, Eigen::Vector2d(p1.position.x, p1.position.y));
@@ -117,21 +117,23 @@ using Polygon = bg::model::polygon<Point, false>;
 
 TrafficLightModule::TrafficLightModule(
   const int64_t module_id, const lanelet::TrafficLight & traffic_light_reg_elem,
-  lanelet::ConstLanelet lane, const PlannerParam & planner_param)
-: SceneModuleInterface(module_id),
+  lanelet::ConstLanelet lane, const PlannerParam & planner_param, const rclcpp::Logger logger,
+  const rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock),
+  lane_id_(lane.id()),
   traffic_light_reg_elem_(traffic_light_reg_elem),
   lane_(lane),
-  lane_id_(lane.id()),
   state_(State::APPROACH)
 {
   planner_param_ = planner_param;
 }
 
 bool TrafficLightModule::modifyPathVelocity(
-  autoware_planning_msgs::msg::PathWithLaneId * path, autoware_planning_msgs::msg::StopReason * stop_reason)
+  autoware_planning_msgs::msg::PathWithLaneId * path,
+  autoware_planning_msgs::msg::StopReason * stop_reason)
 {
   debug_data_ = {};
-  debug_data_.base_link2front = planner_data_->base_link2front;
+  debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m_;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
   *stop_reason =
     planning_utils::initializeStopReason(autoware_planning_msgs::msg::StopReason::TRAFFIC_LIGHT);
@@ -196,17 +198,17 @@ bool TrafficLightModule::modifyPathVelocity(
         // judge pass or stop
         if (
           (calcSignedArcLength(input_path, self_pose.pose, stop_line_point) <
-           pass_judge_line_distance + planner_data_->base_link2front) &&
+           pass_judge_line_distance + planner_data_->vehicle_info_.max_longitudinal_offset_m_) &&
           (3.0 /* =10.8km/h */ < self_twist_ptr->twist.linear.x)) {
-          ROS_WARN_THROTTLE(
-            1.0, "[traffic_light] vehicle is over stop border (%f m)",
-            pass_judge_line_distance + planner_data_->base_link2front);
+          RCLCPP_WARN_THROTTLE(
+            logger_, *clock_, 1.0, "[traffic_light] vehicle is over stop border (%f m)",
+            pass_judge_line_distance + planner_data_->vehicle_info_.max_longitudinal_offset_m_);
           return true;
         } else {
           // Add Stop WayPoint
           if (!insertTargetVelocityPoint(
                 input_path, stop_line, planner_param_.stop_margin, 0.0, *path)) {
-            ROS_WARN("[traffic_light] cannot insert stop waypoint");
+            RCLCPP_WARN(logger_, "[traffic_light] cannot insert stop waypoint");
             continue;
           }
         }
@@ -227,7 +229,8 @@ bool TrafficLightModule::modifyPathVelocity(
 }
 
 bool TrafficLightModule::isOverDeadLine(
-  const geometry_msgs::msg::Pose & self_pose, const autoware_planning_msgs::msg::PathWithLaneId & input_path,
+  const geometry_msgs::msg::Pose & self_pose,
+  const autoware_planning_msgs::msg::PathWithLaneId & input_path,
   const size_t & dead_line_point_idx, const Eigen::Vector2d & dead_line_point,
   const double dead_line_range)
 {
@@ -263,7 +266,7 @@ bool TrafficLightModule::isOverDeadLine(
   }
 
   if (0 < tf_dead_line_pose2self_pose.getOrigin().x()) {
-    ROS_WARN("[traffic_light] vehicle is over dead line");
+    RCLCPP_WARN(logger_, "[traffic_light] vehicle is over dead line");
     return true;
   }
 
@@ -283,15 +286,20 @@ bool TrafficLightModule::isStopRequired(
     return true;
   }
 
-  if (turn_direction == "right" && hasLamp(tl_state, autoware_perception_msgs::msg::LampState::RIGHT)) {
+  if (
+    turn_direction == "right" &&
+    hasLamp(tl_state, autoware_perception_msgs::msg::LampState::RIGHT)) {
     return false;
   }
 
-  if (turn_direction == "left" && hasLamp(tl_state, autoware_perception_msgs::msg::LampState::LEFT)) {
+  if (
+    turn_direction == "left" && hasLamp(tl_state, autoware_perception_msgs::msg::LampState::LEFT)) {
     return false;
   }
 
-  if (turn_direction == "straight" && hasLamp(tl_state, autoware_perception_msgs::msg::LampState::UP)) {
+  if (
+    turn_direction == "straight" &&
+    hasLamp(tl_state, autoware_perception_msgs::msg::LampState::UP)) {
     return false;
   }
 
@@ -322,7 +330,7 @@ bool TrafficLightModule::getHighestConfidenceTrafficLightState(
 
     const auto header = tl_state_stamped->header;
     const auto tl_state = tl_state_stamped->state;
-    if (!((this->now() - header.stamp).toSec() < planner_param_.tl_state_timeout)) {
+    if (!((clock_->now() - header.stamp).seconds() < planner_param_.tl_state_timeout)) {
       reason = "TimeOut";
       continue;
     }
@@ -345,8 +353,9 @@ bool TrafficLightModule::getHighestConfidenceTrafficLightState(
     found = true;
   }
   if (!found) {
-    ROS_WARN_THROTTLE(
-      1.0, "[traffic_light] cannot find traffic light lamp state (%s).", reason.c_str());
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 1.0, "[traffic_light] cannot find traffic light lamp state (%s).",
+      reason.c_str());
     return false;
   }
   return true;
@@ -356,7 +365,8 @@ bool TrafficLightModule::insertTargetVelocityPoint(
   const autoware_planning_msgs::msg::PathWithLaneId & input,
   const boost::geometry::model::linestring<boost::geometry::model::d2::point_xy<double>> &
     stop_line,
-  const double & margin, const double & velocity, autoware_planning_msgs::msg::PathWithLaneId & output)
+  const double & margin, const double & velocity,
+  autoware_planning_msgs::msg::PathWithLaneId & output)
 {
   // create target point
   Eigen::Vector2d target_point;
@@ -419,7 +429,7 @@ bool TrafficLightModule::createTargetPoint(
 
     // search target point index
     target_point_idx = 0;
-    const double base_link2front = planner_data_->base_link2front;
+    const double base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m_;
     double length_sum = 0;
 
     const double target_length = margin + base_link2front;

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/interpolate.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/interpolate.cpp
@@ -69,7 +69,7 @@ bool isIncrease(const std::vector<double> & x)
     if (x[i] > x[i + 1]) return false;
   }
   return true;
-};
+}
 
 bool isValidInput(
   const std::vector<double> & base_index, const std::vector<double> & base_value,

--- a/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/util.cpp
+++ b/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/src/utilization/util.cpp
@@ -71,14 +71,14 @@ bool calcClosestIndex(
 }
 
 template bool calcClosestIndex<autoware_planning_msgs::msg::Trajectory>(
-  const autoware_planning_msgs::msg::Trajectory & path, const geometry_msgs::msg::Pose & pose, int & closest,
-  double dist_thr, double angle_thr);
+  const autoware_planning_msgs::msg::Trajectory & path, const geometry_msgs::msg::Pose & pose,
+  int & closest, double dist_thr, double angle_thr);
 template bool calcClosestIndex<autoware_planning_msgs::msg::PathWithLaneId>(
   const autoware_planning_msgs::msg::PathWithLaneId & path, const geometry_msgs::msg::Pose & pose,
   int & closest, double dist_thr, double angle_thr);
 template bool calcClosestIndex<autoware_planning_msgs::msg::Path>(
-  const autoware_planning_msgs::msg::Path & path, const geometry_msgs::msg::Pose & pose, int & closest,
-  double dist_thr, double angle_thr);
+  const autoware_planning_msgs::msg::Path & path, const geometry_msgs::msg::Pose & pose,
+  int & closest, double dist_thr, double angle_thr);
 
 template <class T>
 bool calcClosestIndex(
@@ -108,8 +108,8 @@ template bool calcClosestIndex<autoware_planning_msgs::msg::PathWithLaneId>(
   const autoware_planning_msgs::msg::PathWithLaneId & path, const geometry_msgs::msg::Point & point,
   int & closest, double dist_thr);
 template bool calcClosestIndex<autoware_planning_msgs::msg::Path>(
-  const autoware_planning_msgs::msg::Path & path, const geometry_msgs::msg::Point & point, int & closest,
-  double dist_thr);
+  const autoware_planning_msgs::msg::Path & path, const geometry_msgs::msg::Point & point,
+  int & closest, double dist_thr);
 
 geometry_msgs::msg::Pose transformRelCoordinate2D(
   const geometry_msgs::msg::Pose & target, const geometry_msgs::msg::Pose & origin)


### PR DESCRIPTION
* For logging and time purposes, I gave the `SceneModuleInterface` and `SceneModuleManagerInterface` base classes a logger and a clock, which have to be passed into the child classes' constructors.
* In the debug.cpp files, I could have passed in a clock into each of the free functions, but preferred to set the stamp in `appendMarkerArray`.
* Used VehicleInfo (https://github.com/tier4/Pilot.Auto/pull/58), so that e.g. `planner_data_->base_link2front` was replaced with with `planner_data_->vehicle_info_.max_longitudinal_offset_m`
* One message was not built in `autoware_perception_msgs`, this fixes that
* Added missing dependencies, e.g. `diagnostic_msgs`
* Fixed a few `size_t` to `int` comparison warnings, sometimes by casting, sometimes by changing the loop variable to `size_t`
* Deleted a few unused functions
* "StopLineModule::modifyPathVelocity" and another function had no return statements.
* Tightened the includes in headers a bit – for instance, many `scene.h` files included Eigen, or `unordered_map` and didn't use it at all.

Interesting changes:
* The `waitForTransform` defined in here (not the same as `waitForTransform` in Foxy!) was only used in one place, in `onTrigger()`, to wait for the first `map->base_link` transform to arrive. `onTrigger()` already returns early when certain messages have not yet been received, and I simply did the same when the transform isn't available. 